### PR TITLE
added go-get instructions for xcaddy in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Versions can be anything compatible with `go get`.
 
 The CLI can be used both to make custom builds of Caddy, but also as a replacement for `go run` while developing Caddy plugins.
 
+### Download
+
+```
+go get -u github.com/caddyserver/xcaddy/cmd/xcaddy
+```
+
 ### For custom builds
 
 Syntax:


### PR DESCRIPTION
The pull request adds go-gettable instructions for `xcaddy`.
@Mohammed90 

Signed-off-by: Ankur Srivastava <ankur.srivastava@email.de>