### PR TITLE
update library usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ builder := xcaddy.Builder{
 		},
 	},
 }
-err := builder.Build("./caddy")
+err := builder.Build(context.Background(), "./caddy")
 ```
 
 Versions can be anything compatible with `go get`.


### PR DESCRIPTION
The func `Build` has two parameters:

```
func (b Builder) Build(ctx context.Context, outputFile string) error
```