### PR TITLE
make customized env effective

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -90,6 +90,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 		"-ldflags", "-w -s", // trim debug symbols
 		"-trimpath",
 	)
+	cmd.Env = env
 	err = buildEnv.runCommand(ctx, cmd, 5*time.Minute)
 	if err != nil {
 		return err


### PR DESCRIPTION
I find that customized platform is not work,  like this:

```go
builder := xcaddy.Builder{
	Compile: xcaddy.Compile{
		Platform: xcaddy.Platform{
			OS:   "linux",
			Arch: "amd64",
		},
	},
	CaddyVersion: CaddyVersion,
	Plugins:      []xcaddy.Dependency{},
}
```
