### PR TITLE
add help and version cli args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/caddyserver/xcaddy
 
 go 1.14
 
-require github.com/Masterminds/semver/v3 v3.1.0
+require (
+	github.com/Masterminds/semver/v3 v3.1.0
+	github.com/greenpau/versioned v1.0.18 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/greenpau/versioned v1.0.18 h1:R6Vwm9j97CVife4KESf4xdbViUwrjNCLr1hWFfbeVUY=
+github.com/greenpau/versioned v1.0.18/go.mod h1:rtFCvaWWNbMH4CJnje/xicgmrM63j++rUh5juSu0k/A=


### PR DESCRIPTION
For example:

help:

```
$ ./xcaddy --help

xcaddy - Build Caddy with plugins

Usage: xcaddy [arguments]

  xcaddy build [<caddy_version>]
    [--output <file>]
    [--with <module[@version][=replacement]>...]

Documentation: https://github.com/caddyserver/xcaddy
```

version:

```
$ ./xcaddy --version
xcaddy v0.1.3
```

