### PR TITLE
ci: immediately publish releases on tags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,13 +61,14 @@ release:
   github:
     owner: caddyserver
     name: xcaddy
-  draft: true
+  draft: false
   prerelease: auto
 
 changelog:
   sort: asc
   filters:
     exclude:
+    - '^readme:'
     - '^chore:'
     - '^ci:'
     - '^docs?:'


### PR DESCRIPTION
The releases of xcaddy don't need handcrafted release notes, so immediate publishing is fine.