### PR TITLE
Fix main.go generation when executing on a windows machine

### DIFF
--- a/cmd/xcaddy/main.go
+++ b/cmd/xcaddy/main.go
@@ -243,7 +243,7 @@ func runDev(ctx context.Context, args []string) error {
 	return cmd.Wait()
 }
 
-func normalizeImportPath(currentModule string, cwd string, moduleDir string) string {
+func normalizeImportPath(currentModule, cwd, moduleDir string) string {
 	return path.Join(currentModule, filepath.ToSlash(strings.TrimPrefix(cwd, moduleDir)))
 }
 

--- a/cmd/xcaddy/main.go
+++ b/cmd/xcaddy/main.go
@@ -199,7 +199,7 @@ func runDev(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to determine current directory: %v", err)
 	}
-	importPath := path.Join(currentModule, strings.TrimPrefix(cwd, filepath.ToSlash(moduleDir)))
+	importPath := normalizeImportPath(currentModule, cwd, moduleDir)
 
 	// build caddy with this module plugged in
 	builder := xcaddy.Builder{
@@ -241,6 +241,10 @@ func runDev(ctx context.Context, args []string) error {
 	}()
 
 	return cmd.Wait()
+}
+
+func normalizeImportPath(currentModule string, cwd string, moduleDir string) string {
+	return path.Join(currentModule, filepath.ToSlash(strings.TrimPrefix(cwd, moduleDir)))
 }
 
 func trapSignals(ctx context.Context, cancel context.CancelFunc) {

--- a/cmd/xcaddy/main_test.go
+++ b/cmd/xcaddy/main_test.go
@@ -72,7 +72,7 @@ func TestSplitWith(t *testing.T) {
 	}
 }
 
-func Test_normalizeImportPath(t *testing.T) {
+func TestNormalizeImportPath(t *testing.T) {
 	type args struct {
 		currentModule string
 		cwd           string

--- a/cmd/xcaddy/main_test.go
+++ b/cmd/xcaddy/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 func TestSplitWith(t *testing.T) {
 	for i, tc := range []struct {
@@ -73,16 +76,20 @@ func TestSplitWith(t *testing.T) {
 }
 
 func TestNormalizeImportPath(t *testing.T) {
-	type args struct {
-		currentModule string
-		cwd           string
-		moduleDir     string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
+	type (
+		args struct {
+			currentModule string
+			cwd           string
+			moduleDir     string
+		}
+		testCaseType []struct {
+			name string
+			args args
+			want string
+		}
+	)
+
+	tests := testCaseType{
 		{"linux-path", args{
 			currentModule: "github.com/caddyserver/xcaddy",
 			cwd:           "/xcaddy",
@@ -93,6 +100,8 @@ func TestNormalizeImportPath(t *testing.T) {
 			cwd:           "/xcaddy/subdir",
 			moduleDir:     "/xcaddy",
 		}, "github.com/caddyserver/xcaddy/subdir"},
+	}
+	windowsTests := testCaseType{
 		{"windows-path", args{
 			currentModule: "github.com/caddyserver/xcaddy",
 			cwd:           "c:\\xcaddy",
@@ -103,6 +112,9 @@ func TestNormalizeImportPath(t *testing.T) {
 			cwd:           "c:\\xcaddy\\subdir",
 			moduleDir:     "c:\\xcaddy",
 		}, "github.com/caddyserver/xcaddy/subdir"},
+	}
+	if runtime.GOOS == "windows" {
+		tests = append(tests, windowsTests...)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/xcaddy/main_test.go
+++ b/cmd/xcaddy/main_test.go
@@ -88,11 +88,21 @@ func TestNormalizeImportPath(t *testing.T) {
 			cwd:           "/xcaddy",
 			moduleDir:     "/xcaddy",
 		}, "github.com/caddyserver/xcaddy"},
+		{"linux-subpath", args{
+			currentModule: "github.com/caddyserver/xcaddy",
+			cwd:           "/xcaddy/subdir",
+			moduleDir:     "/xcaddy",
+		}, "github.com/caddyserver/xcaddy/subdir"},
 		{"windows-path", args{
 			currentModule: "github.com/caddyserver/xcaddy",
 			cwd:           "c:\\xcaddy",
 			moduleDir:     "c:\\xcaddy",
 		}, "github.com/caddyserver/xcaddy"},
+		{"windows-subpath", args{
+			currentModule: "github.com/caddyserver/xcaddy",
+			cwd:           "c:\\xcaddy\\subdir",
+			moduleDir:     "c:\\xcaddy",
+		}, "github.com/caddyserver/xcaddy/subdir"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/xcaddy/main_test.go
+++ b/cmd/xcaddy/main_test.go
@@ -71,3 +71,34 @@ func TestSplitWith(t *testing.T) {
 		}
 	}
 }
+
+func Test_normalizeImportPath(t *testing.T) {
+	type args struct {
+		currentModule string
+		cwd           string
+		moduleDir     string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"linux-path", args{
+			currentModule: "github.com/caddyserver/xcaddy",
+			cwd:           "/xcaddy",
+			moduleDir:     "/xcaddy",
+		}, "github.com/caddyserver/xcaddy"},
+		{"windows-path", args{
+			currentModule: "github.com/caddyserver/xcaddy",
+			cwd:           "c:\\xcaddy",
+			moduleDir:     "c:\\xcaddy",
+		}, "github.com/caddyserver/xcaddy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeImportPath(tt.args.currentModule, tt.args.cwd, tt.args.moduleDir); got != tt.want {
+				t.Errorf("normalizeImportPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When normalizing the `importPath` it will try to write on `main.go` files with imports
like `github.com/caddyserver/xcaddy/c:\xcaddy`

The fix is basically changing from `path.Join(currentModule, strings.TrimPrefix(cwd, filepath.ToSlash(moduleDir)))` to `path.Join(currentModule, filepath.ToSlash(strings.TrimPrefix(cwd, moduleDir)))`