### PR TITLE
feat: add XCADDY_NO_BUILD to not run go build

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ Because the subcommands and flags are constrained to benefit rapid plugin protot
 
 - `CADDY_VERSION` sets the version of Caddy to build.
 - `XCADDY_RACE_DETECTOR=1` enables the Go race detector in the build.
-- `XCADDY_SKIP_CLEANUP=1` causes xcaddy to leave build artifacts on disk after exiting.
 - `XCADDY_SETCAP=1` will run `sudo setcap cap_net_bind_service=+ep` on the temporary binary before running it when in dev mode.
+- `XCADDY_SKIP_BUILD=1` causes xcaddy to not compile the program, it is used in conjunction with build tools such as [GoReleaser](https://goreleaser.com). Implies `XCADDY_SKIP_CLEANUP=1`.
+- `XCADDY_SKIP_CLEANUP=1` causes xcaddy to leave build artifacts on disk after exiting.
 
 ---
 

--- a/builder.go
+++ b/builder.go
@@ -42,6 +42,7 @@ type Builder struct {
 	TimeoutBuild time.Duration `json:"timeout_build,omitempty"`
 	RaceDetector bool          `json:"race_detector,omitempty"`
 	SkipCleanup  bool          `json:"skip_cleanup,omitempty"`
+	NoBuild      bool          `json:"no_build,omitempty"`
 }
 
 // Build builds Caddy at the configured version with the
@@ -76,6 +77,12 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 		return err
 	}
 	defer buildEnv.Close()
+
+	if b.NoBuild {
+		log.Printf("[INFO] Skipping build as requested")
+
+		return nil
+	}
 
 	// prepare the environment for the go command; for
 	// the most part we want it to inherit our current

--- a/builder.go
+++ b/builder.go
@@ -42,7 +42,7 @@ type Builder struct {
 	TimeoutBuild time.Duration `json:"timeout_build,omitempty"`
 	RaceDetector bool          `json:"race_detector,omitempty"`
 	SkipCleanup  bool          `json:"skip_cleanup,omitempty"`
-	NoBuild      bool          `json:"no_build,omitempty"`
+	SkipBuild    bool          `json:"skip_build,omitempty"`
 }
 
 // Build builds Caddy at the configured version with the
@@ -78,7 +78,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	}
 	defer buildEnv.Close()
 
-	if b.NoBuild {
+	if b.SkipBuild {
 		log.Printf("[INFO] Skipping build as requested")
 
 		return nil

--- a/cmd/xcaddy/main.go
+++ b/cmd/xcaddy/main.go
@@ -32,7 +32,8 @@ import (
 var (
 	caddyVersion = os.Getenv("CADDY_VERSION")
 	raceDetector = os.Getenv("XCADDY_RACE_DETECTOR") == "1"
-	skipCleanup  = os.Getenv("XCADDY_SKIP_CLEANUP") == "1"
+	noBuild      = os.Getenv("XCADDY_NO_BUILD") == "1"
+	skipCleanup  = noBuild || os.Getenv("XCADDY_SKIP_CLEANUP") == "1"
 )
 
 func main() {
@@ -112,6 +113,7 @@ func runBuild(ctx context.Context, args []string) error {
 		Replacements: replacements,
 		RaceDetector: raceDetector,
 		SkipCleanup:  skipCleanup,
+		NoBuild:      noBuild,
 	}
 	err := builder.Build(ctx, output)
 	if err != nil {
@@ -217,6 +219,7 @@ func runDev(ctx context.Context, args []string) error {
 		Replacements: replacements,
 		RaceDetector: raceDetector,
 		SkipCleanup:  skipCleanup,
+		NoBuild:      noBuild,
 	}
 	err = builder.Build(ctx, binOutput)
 	if err != nil {

--- a/cmd/xcaddy/main.go
+++ b/cmd/xcaddy/main.go
@@ -32,8 +32,8 @@ import (
 var (
 	caddyVersion = os.Getenv("CADDY_VERSION")
 	raceDetector = os.Getenv("XCADDY_RACE_DETECTOR") == "1"
-	noBuild      = os.Getenv("XCADDY_NO_BUILD") == "1"
-	skipCleanup  = noBuild || os.Getenv("XCADDY_SKIP_CLEANUP") == "1"
+	skipBuild    = os.Getenv("XCADDY_SKIP_BUILD") == "1"
+	skipCleanup  = skipBuild || os.Getenv("XCADDY_SKIP_CLEANUP") == "1"
 )
 
 func main() {
@@ -113,7 +113,7 @@ func runBuild(ctx context.Context, args []string) error {
 		Replacements: replacements,
 		RaceDetector: raceDetector,
 		SkipCleanup:  skipCleanup,
-		NoBuild:      noBuild,
+		SkipBuild:    skipBuild,
 	}
 	err := builder.Build(ctx, output)
 	if err != nil {
@@ -143,7 +143,7 @@ func getCaddyOutputFile() string {
 	if runtime.GOOS == "windows" {
 		return "caddy.exe"
 	}
-	return "." + string(filepath.Separator) + "caddy"
+	return "caddy"
 }
 
 func runDev(ctx context.Context, args []string) error {
@@ -177,7 +177,7 @@ func runDev(ctx context.Context, args []string) error {
 	// and since this tool is a carry-through for the user's actual
 	// go.mod, we need to transfer their replace directives through
 	// to the one we're making
-	cmd = exec.Command("go", "list", "-m", "-f={{if .Replace}}{{.Path}}=>{{.Replace}}{{end}}", "all")
+	cmd = exec.Command("go", "list", "-m", "-f={{if .Replace}}{{.Path}} => {{.Replace}}{{end}}", "all")
 	cmd.Stderr = os.Stderr
 	out, err = cmd.Output()
 	if err != nil {
@@ -188,14 +188,10 @@ func runDev(ctx context.Context, args []string) error {
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			continue
 		}
-
-		// adjust relative replacements in original module since our temporary module is in a different directory
-		if !filepath.IsAbs(parts[1]) {
-			parts[1] = filepath.Join(moduleDir, parts[1])
-			log.Printf("[INFO] Resolved relative replacement %s to %s", line, parts[1])
-		}
-
-		replacements = append(replacements, xcaddy.NewReplace(parts[0], parts[1]))
+		replacements = append(replacements, xcaddy.NewReplace(
+			strings.TrimSpace(parts[0]),
+			strings.TrimSpace(parts[1]),
+		))
 	}
 
 	// reconcile remaining path segments; for example if a module foo/a
@@ -219,21 +215,11 @@ func runDev(ctx context.Context, args []string) error {
 		Replacements: replacements,
 		RaceDetector: raceDetector,
 		SkipCleanup:  skipCleanup,
-		NoBuild:      noBuild,
+		SkipBuild:    skipBuild,
 	}
 	err = builder.Build(ctx, binOutput)
 	if err != nil {
 		return err
-	}
-
-	if os.Getenv("XCADDY_SETCAP") == "1" {
-		cmd = exec.Command("sudo", "setcap", "cap_net_bind_service=+ep", binOutput)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		log.Printf("[INFO] Setting capabilities (requires admin privileges): %v", cmd.Args)
-		if err = cmd.Run(); err != nil {
-			return err
-		}
 	}
 
 	log.Printf("[INFO] Running %v\n\n", append([]string{binOutput}, args...))


### PR DESCRIPTION
[Mercure](https://mercure.rocks) and [Vulcain](https://vulcain.rocks) now use Caddy. They are available as Caddy modules but also as standalone binaries build with [GoReleaser](https://goreleaser.com/).
I managed to use `xcaddy` to prepare the source code and `goreleaser` to cross-compile and package the binary: dunglas/mercure#398.

Currently, `xcaddy` always compiles the project. This proposed `XCADDY_NO_BUILD` environment variable allows to prepare the source code but not run `go build` to save some CI time (`go build` is run by GoReleaser).