### PR TITLE
ci: Pull updates from Caddy, build .deb as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go-version: [ 1.14.x ]
+        go: [ '1.14', '1.15' ]
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
-        # XCADDY_BIN_PATH: the path to the compiled Caddy binary, for artifact publishing
+        # XCADDY_BIN_PATH: the path to the compiled xcaddy binary, for artifact publishing
         # SUCCESS: the typical value for $? per OS (Windows/pwsh returns 'True')
         include:
         - os: ubuntu-latest
@@ -39,9 +39,9 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: ${{ matrix.go }}
 
     - name: Checkout code
       uses: actions/checkout@v2
@@ -60,18 +60,18 @@ jobs:
         echo "::set-output name=go_cache::$(go env GOCACHE)"
 
     - name: Cache the build cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ${{ steps.vars.outputs.go_cache }}
-        key: ${{ runner.os }}-go-ci-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-${{ matrix.go }}-go-ci-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-ci
+          ${{ runner.os }}-${{ matrix.go }}-go-ci
 
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
 
-    - name: Build xCaddy
+    - name: Build xcaddy
       working-directory: ./cmd/xcaddy
       env:
         CGO_ENABLED: 0
@@ -81,7 +81,7 @@ jobs:
     - name: Publish Build Artifact
       uses: actions/upload-artifact@v1
       with:
-        name: xcaddy_${{ runner.os }}_${{ steps.vars.outputs.short_sha }}
+        name: xcaddy_${{ runner.os }}_go${{ matrix.go }}_${{ steps.vars.outputs.short_sha }}
         path: ${{ matrix.XCADDY_BIN_PATH }}
 
     - name: Run tests
@@ -107,7 +107,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - uses: goreleaser/goreleaser-action@v1
+      - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,6 @@ jobs:
     - name: Unshallowify the repo clone
       run: git fetch --prune --unshallow
 
-    # Cloudsmith CLI tooling for pushing releases
-    - name: Install Cloudsmith CLI
-      run: pip install --upgrade cloudsmith-cli
-
     # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
     - name: Print Go version and environment
       id: vars
@@ -45,6 +41,9 @@ jobs:
         echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
         echo "::set-output name=go_cache::$(go env GOCACHE)"
 
+        # Add "pip install" CLI tools to PATH
+        echo ~/.local/bin >> $GITHUB_PATH
+
         # Parse semver
         TAG=${GITHUB_REF/refs\/tags\//}
         SEMVER_RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z\.-]*\)'
@@ -56,6 +55,11 @@ jobs:
         echo "::set-output name=tag_minor::${TAG_MINOR}"
         echo "::set-output name=tag_patch::${TAG_PATCH}"
         echo "::set-output name=tag_special::${TAG_SPECIAL}"
+
+    # Cloudsmith CLI tooling for pushing releases
+    # See https://help.cloudsmith.io/docs/cli
+    - name: Install Cloudsmith CLI
+      run: pip install --upgrade cloudsmith-cli
 
     - name: Cache the build cache
       uses: actions/cache@v2
@@ -80,8 +84,7 @@ jobs:
     - name: Publish .deb to Cloudsmith
       if: ${{ steps.vars.outputs.tag_special == '' }}
       env:
-        # TODO:
-        # CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
       run: |
         for filename in dist/*.deb; do
           # armv6 and armv7 are both "armhf" so we can skip the duplicate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
     - name: Unshallowify the repo clone
       run: git fetch --prune --unshallow
 
+    # Cloudsmith CLI tooling for pushing releases
+    - name: Install Cloudsmith CLI
+      run: pip install --upgrade cloudsmith-cli
+
     # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
     - name: Print Go version and environment
       id: vars
@@ -70,3 +74,22 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ steps.vars.outputs.version_tag }}
+
+    # Publish only stable releases to Cloudsmith
+    # See https://cloudsmith.io/~caddy/repos/xcaddy/
+    - name: Publish .deb to Cloudsmith
+      if: ${{ steps.vars.outputs.tag_special == '' }}
+      env:
+        # TODO:
+        # CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+      run: |
+        for filename in dist/*.deb; do
+          # armv6 and armv7 are both "armhf" so we can skip the duplicate
+          if [[ "$filename" == *"armv7"* ]]; then
+            echo "Skipping $filename"
+            continue
+          fi
+
+          echo "Pushing $filename to 'testing'"
+          cloudsmith push deb caddy/xcaddy/any-distro/any-version $filename
+        done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        go-version: [ 1.14.x ]
+        go: [ '1.15' ]
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: ${{ matrix.go }}
 
     - name: Checkout code
       uses: actions/checkout@v2
@@ -27,6 +27,7 @@ jobs:
     - name: Unshallowify the repo clone
       run: git fetch --prune --unshallow
 
+    # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
     - name: Print Go version and environment
       id: vars
       run: |
@@ -36,22 +37,36 @@ jobs:
         go env
         printf "\n\nSystem environment:\n\n"
         env
+        echo "::set-output name=version_tag::${GITHUB_REF/refs\/tags\//}"
         echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
         echo "::set-output name=go_cache::$(go env GOCACHE)"
 
+        # Parse semver
+        TAG=${GITHUB_REF/refs\/tags\//}
+        SEMVER_RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z\.-]*\)'
+        TAG_MAJOR=`echo ${TAG#v} | sed -e "s#$SEMVER_RE#\1#"`
+        TAG_MINOR=`echo ${TAG#v} | sed -e "s#$SEMVER_RE#\2#"`
+        TAG_PATCH=`echo ${TAG#v} | sed -e "s#$SEMVER_RE#\3#"`
+        TAG_SPECIAL=`echo ${TAG#v} | sed -e "s#$SEMVER_RE#\4#"`
+        echo "::set-output name=tag_major::${TAG_MAJOR}"
+        echo "::set-output name=tag_minor::${TAG_MINOR}"
+        echo "::set-output name=tag_patch::${TAG_PATCH}"
+        echo "::set-output name=tag_special::${TAG_SPECIAL}"
+
     - name: Cache the build cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ${{ steps.vars.outputs.go_cache }}
-        key: ${{ runner.os }}-go-release-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go${{ matrix.go }}-release-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-release
+          ${{ runner.os }}-go${{ matrix.go }}-release
 
     # GoReleaser will take care of publishing those artifacts into the release
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v1
+      uses: goreleaser/goreleaser-action@v2
       with:
         version: latest
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ steps.vars.outputs.version_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       run: |
         for filename in dist/*.deb; do
           # armv6 and armv7 are both "armhf" so we can skip the duplicate
-          if [[ "$filename" == *"armv7"* ]]; then
+          if [[ "$filename" == *"armv6"* ]]; then
             echo "Skipping $filename"
             continue
           fi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,6 +56,22 @@ archives:
 checksum:
   algorithm: sha512
 
+nfpms:
+  - id: default
+    package_name: xcaddy
+
+    vendor: Light Code Labs
+    homepage: https://caddyserver.com
+    maintainer: Matthew Holt <mholt@users.noreply.github.com>
+    description: |
+      Build Caddy with plugins
+    license: Apache 2.0
+
+    formats:
+      - deb
+      # - rpm
+
+    bindir: /usr/bin
 
 release:
   github:


### PR DESCRIPTION
FYI @Mohammed90 @mholt 

Three commits:
1. brings the `release.yml` in line with the `caddy` repo's, and adds simple `.deb` packaging (no extra files or scripting, just the `/usr/bin/xcaddy`)
2. brings the `ci.yml` in line with the `caddy` repo's, including testing on Go 1.15
3. adds Cloudsmith .deb publishing (which is why I'm marking this as draft, until https://github.com/caddyserver/caddy/pull/3941 is complete and tested)