### PR TITLE
ci: Fix echo message on Cloudsmith push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,6 @@ jobs:
             continue
           fi
 
-          echo "Pushing $filename to 'testing'"
+          echo "Pushing $filename to 'xcaddy'"
           cloudsmith push deb caddy/xcaddy/any-distro/any-version $filename
         done


### PR DESCRIPTION
We're actually pushing to the `xcaddy` cloudsmith repo, not `testing` (copy-pasted from `caddy` repo, so it had the wrong string). Purely a visual bug.