### PR TITLE
Run `go mod tidy` in the build environment

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -94,7 +94,9 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 
 	// tidy the module to ensure go.mod and go.sum are consistent with the module prereq
 	tidyCmd := buildEnv.newCommand("go", "mod", "tidy")
-	buildEnv.runCommand(ctx, tidyCmd, b.TimeoutGet)
+	if err := buildEnv.runCommand(ctx, tidyCmd, b.TimeoutGet); err != nil {
+		return err
+	}
 
 	// compile
 	cmd := buildEnv.newCommand("go", "build",

--- a/builder.go
+++ b/builder.go
@@ -92,6 +92,10 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 
 	log.Println("[INFO] Building Caddy")
 
+	// tidy the module to ensure go.mod and go.sum are consistent with the module prereq
+	tidyCmd := buildEnv.newCommand("go", "mod", "tidy")
+	buildEnv.runCommand(ctx, tidyCmd, b.TimeoutGet)
+
 	// compile
 	cmd := buildEnv.newCommand("go", "build",
 		"-o", absOutputFile,


### PR DESCRIPTION
As of go 1.16, the `go {build,test}` commands don't modify the go.mod and go.sum files (see: https://golang.org/issue/40728). We, therefore, have to run `go mod tidy` to ensure the go.mod and go.sum files are consistent with the module requirements.

Closes #46