### PR TITLE
Resolve relative replacements for `xcaddy build` as well

### DIFF
--- a/cmd/xcaddy/main.go
+++ b/cmd/xcaddy/main.go
@@ -75,6 +75,14 @@ func runBuild(ctx context.Context, args []string) error {
 				Version:     ver,
 			})
 			if repl != "" {
+				// adjust relative replacements in current working directory since our temporary module is in a different directory
+				if !filepath.IsAbs(repl) {
+					repl, err = filepath.Abs(repl)
+					if err != nil {
+						log.Fatalf("[FATAL] %v", err)
+					}
+					log.Printf("[INFO] Resolved relative replacement %s to %s", args[i], repl)
+				}
 				replacements = append(replacements, xcaddy.NewReplace(mod, repl))
 			}
 


### PR DESCRIPTION
To match the change in 623c3617263ddcceea808ea4e7edcc6ebe43a837, this resolves the replacement path ahead of time for `xcaddy build`.

My usecase is to make this command work:

```
$ xcaddy build --with github.com/caddyserver/caddy/v2=../../../caddy
```

Before this change, the output would read:

```
$ .\xcaddy.exe build --with github.com/caddyserver/caddy/v2=..\..\..\caddy                             2021/02/13 19:53:13 [INFO] Temporary folder: C:\Users\lavof\AppData\Local\Temp\buildenv_2021-02-13-1953.141206587
2021/02/13 19:53:13 [INFO] Writing main module: C:\Users\lavof\AppData\Local\Temp\buildenv_2021-02-13-1953.141206587\main.go
2021/02/13 19:53:13 [INFO] Initializing Go module
2021/02/13 19:53:13 [INFO] exec (timeout=10s): C:\Users\lavof\scoop\shims\go.exe mod init caddy
go: creating new go.mod: module caddy
2021/02/13 19:53:13 [INFO] Replace github.com/caddyserver/caddy/v2 => ..\..\..\caddy
2021/02/13 19:53:13 [INFO] exec (timeout=10s): C:\Users\lavof\scoop\shims\go.exe mod edit -replace github.com/caddyserver/caddy/v2=..\..\..\caddy
2021/02/13 19:53:13 [INFO] Pinning versions
2021/02/13 19:53:13 [INFO] exec (timeout=0s): C:\Users\lavof\scoop\shims\go.exe get -d -v github.com/caddyserver/caddy/vgo get github.com/caddyserver/caddy/v2: github.com/caddyserver/caddy/v2@v2.3.0: replacement directory ..\..\..\caddy does not exist
2021/02/13 19:53:13 [FATAL] exit status 1
```

After:

```
$ .\xcaddy.exe build --with github.com/caddyserver/caddy/v2=..\..\..\caddy
2021/02/13 20:00:31 [INFO] Resolved relative replacement github.com/caddyserver/caddy/v2=..\..\..\caddy to C:\Users\lavof\repos\caddy
2021/02/13 20:00:31 [INFO] Temporary folder: C:\Users\lavof\AppData\Local\Temp\buildenv_2021-02-13-2000.328255839
2021/02/13 20:00:31 [INFO] Writing main module: C:\Users\lavof\AppData\Local\Temp\buildenv_2021-02-13-2000.328255839\main.go
2021/02/13 20:00:31 [INFO] Initializing Go module
2021/02/13 20:00:31 [INFO] exec (timeout=10s): C:\Users\lavof\scoop\shims\go.exe mod init caddy
go: creating new go.mod: module caddy
2021/02/13 20:00:31 [INFO] Replace github.com/caddyserver/caddy/v2 => C:\Users\lavof\repos\caddy
2021/02/13 20:00:31 [INFO] exec (timeout=10s): C:\Users\lavof\scoop\shims\go.exe mod edit -replace github.com/caddyserver/caddy/v2=C:\Users\lavof\repos\caddy
2021/02/13 20:00:31 [INFO] Pinning versions
2021/02/13 20:00:31 [INFO] exec (timeout=0s): C:\Users\lavof\scoop\shims\go.exe get -d -v github.com/caddyserver/caddy/v2
go: github.com/caddyserver/caddy/v2 upgrade => v2.3.0
2021/02/13 20:00:31 [INFO] Build environment ready
2021/02/13 20:00:31 [INFO] Building Caddy
2021/02/13 20:00:31 [INFO] exec (timeout=0s): C:\Users\lavof\scoop\shims\go.exe mod tidy
2021/02/13 20:00:32 [INFO] exec (timeout=0s): C:\Users\lavof\scoop\shims\go.exe build -o C:\Users\lavof\repos\xcaddy\cmd\xcaddy\caddy.exe -ldflags -w -s -trimpath
2021/02/13 20:00:34 [INFO] Build complete: caddy.exe
2021/02/13 20:00:34 [INFO] Cleaning up temporary folder: C:\Users\lavof\AppData\Local\Temp\buildenv_2021-02-13-2000.328255839
```