### PR TITLE
feat: enable DWARF debug info in the build by setting XCADDY_DEBUG=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# `xcaddy` - Custom Caddy Builder
+`xcaddy` - Custom Caddy Builder
+===============================
 
 This command line tool and associated Go package makes it easy to make custom builds of the [Caddy Web Server](https://github.com/caddyserver/caddy).
 
@@ -14,7 +15,7 @@ Stay updated, be aware of changes, and please submit feedback! Thanks!
 
 ## Install
 
-You can [download binaries](https://github.com/caddyserver/xcaddy/releases) that are already compiled for your platform from the Release tab.
+You can [download binaries](https://github.com/caddyserver/xcaddy/releases) that are already compiled for your platform from the Release tab. 
 
 You may also build `xcaddy` from source:
 
@@ -43,6 +44,7 @@ The `xcaddy` command will use the latest version of Caddy by default. You can cu
 
 As usual with `go` command, the `xcaddy` command will pass the `GOOS`, `GOARCH`, and `GOARM` environment variables through for cross-compilation.
 
+
 ### Custom builds
 
 Syntax:
@@ -51,13 +53,11 @@ Syntax:
 $ xcaddy build [<caddy_version>]
     [--output <file>]
     [--with <module[@version][=replacement]>...]
-    [--debug]
 ```
 
 - `<caddy_version>` is the core Caddy version to build; defaults to `CADDY_VERSION` env variable or latest.
 - `--output` changes the output file.
 - `--with` can be used multiple times to add plugins by specifying the Go module name and optionally its version, similar to `go get`. Module name is required, but specific version and/or local replacement are optional.
-- `--debug` can be used to build an output with DWARF debug information turned on.
 
 Examples:
 
@@ -97,7 +97,6 @@ Syntax:
 ```
 $ xcaddy <args...>
 ```
-
 - `<args...>` are passed through to the `caddy` command.
 
 For example:
@@ -108,7 +107,8 @@ $ xcaddy run
 $ xcaddy run --config caddy.json
 ```
 
-The race detector can be enabled by setting `XCADDY_RACE_DETECTOR=1`.
+The race detector can be enabled by setting `XCADDY_RACE_DETECTOR=1`. The DWARF debug info can be enabled by setting `XCADDY_DEBUG=1`.
+
 
 ## Library usage
 
@@ -127,12 +127,15 @@ err := builder.Build(context.Background(), "./caddy")
 
 Versions can be anything compatible with `go get`.
 
+
+
 ## Environment variables
 
 Because the subcommands and flags are constrained to benefit rapid plugin prototyping, xcaddy does read some environment variables to take cues for its behavior and/or configuration when there is no room for flags.
 
 - `CADDY_VERSION` sets the version of Caddy to build.
 - `XCADDY_RACE_DETECTOR=1` enables the Go race detector in the build.
+- `XCADDY_DEBUG=1` enables the DWARF debug information in the build.
 - `XCADDY_SETCAP=1` will run `sudo setcap cap_net_bind_service=+ep` on the temporary binary before running it when in dev mode.
 - `XCADDY_SKIP_BUILD=1` causes xcaddy to not compile the program, it is used in conjunction with build tools such as [GoReleaser](https://goreleaser.com). Implies `XCADDY_SKIP_CLEANUP=1`.
 - `XCADDY_SKIP_CLEANUP=1` causes xcaddy to leave build artifacts on disk after exiting.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ xcaddy build [<caddy_version>]
 - `<caddy_version>` is the core Caddy version to build; defaults to `CADDY_VERSION` env variable or latest.
 - `--output` changes the output file.
 - `--with` can be used multiple times to add plugins by specifying the Go module name and optionally its version, similar to `go get`. Module name is required, but specific version and/or local replacement are optional.
-- `--debug` can be used to build an output with DWARF debug information turns on.
+- `--debug` can be used to build an output with DWARF debug information turned on.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-`xcaddy` - Custom Caddy Builder
-===============================
+# `xcaddy` - Custom Caddy Builder
 
 This command line tool and associated Go package makes it easy to make custom builds of the [Caddy Web Server](https://github.com/caddyserver/caddy).
 
@@ -15,7 +14,7 @@ Stay updated, be aware of changes, and please submit feedback! Thanks!
 
 ## Install
 
-You can [download binaries](https://github.com/caddyserver/xcaddy/releases) that are already compiled for your platform from the Release tab. 
+You can [download binaries](https://github.com/caddyserver/xcaddy/releases) that are already compiled for your platform from the Release tab.
 
 You may also build `xcaddy` from source:
 
@@ -44,7 +43,6 @@ The `xcaddy` command will use the latest version of Caddy by default. You can cu
 
 As usual with `go` command, the `xcaddy` command will pass the `GOOS`, `GOARCH`, and `GOARM` environment variables through for cross-compilation.
 
-
 ### Custom builds
 
 Syntax:
@@ -53,11 +51,13 @@ Syntax:
 $ xcaddy build [<caddy_version>]
     [--output <file>]
     [--with <module[@version][=replacement]>...]
+    [--debug]
 ```
 
 - `<caddy_version>` is the core Caddy version to build; defaults to `CADDY_VERSION` env variable or latest.
 - `--output` changes the output file.
 - `--with` can be used multiple times to add plugins by specifying the Go module name and optionally its version, similar to `go get`. Module name is required, but specific version and/or local replacement are optional.
+- `--debug` can be used to build an output with DWARF debug information turns on.
 
 Examples:
 
@@ -97,6 +97,7 @@ Syntax:
 ```
 $ xcaddy <args...>
 ```
+
 - `<args...>` are passed through to the `caddy` command.
 
 For example:
@@ -108,7 +109,6 @@ $ xcaddy run --config caddy.json
 ```
 
 The race detector can be enabled by setting `XCADDY_RACE_DETECTOR=1`.
-
 
 ## Library usage
 
@@ -126,8 +126,6 @@ err := builder.Build(context.Background(), "./caddy")
 ```
 
 Versions can be anything compatible with `go get`.
-
-
 
 ## Environment variables
 

--- a/builder.go
+++ b/builder.go
@@ -43,6 +43,7 @@ type Builder struct {
 	RaceDetector bool          `json:"race_detector,omitempty"`
 	SkipCleanup  bool          `json:"skip_cleanup,omitempty"`
 	SkipBuild    bool          `json:"skip_build,omitempty"`
+	Debug        bool          `json:"debug,omitempty"`
 }
 
 // Build builds Caddy at the configured version with the
@@ -108,9 +109,14 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	// compile
 	cmd := buildEnv.newCommand("go", "build",
 		"-o", absOutputFile,
-		"-ldflags", "-w -s", // trim debug symbols
-		"-trimpath",
 	)
+	if !b.Debug {
+		cmd.Args = append(cmd.Args,
+			"-ldflags", "-w -s", // trim debug symbols
+			"-trimpath",
+		)
+	}
+
 	if b.RaceDetector {
 		cmd.Args = append(cmd.Args, "-race")
 	}

--- a/cmd/xcaddy/main.go
+++ b/cmd/xcaddy/main.go
@@ -57,7 +57,7 @@ func runBuild(ctx context.Context, args []string) error {
 	// parse the command line args... rather primitively
 	var (
 		argCaddyVersion, output string
-		buildDebugVersion       bool
+		buildDebugOutput        bool
 		plugins                 []xcaddy.Dependency
 		replacements            []xcaddy.Replace
 	)
@@ -98,7 +98,7 @@ func runBuild(ctx context.Context, args []string) error {
 			output = args[i]
 
 		case "--debug":
-			buildDebugVersion = true
+			buildDebugOutput = true
 
 		default:
 			if argCaddyVersion != "" {
@@ -129,7 +129,7 @@ func runBuild(ctx context.Context, args []string) error {
 		RaceDetector: raceDetector,
 		SkipBuild:    skipBuild,
 		SkipCleanup:  skipCleanup,
-		Debug:        buildDebugVersion,
+		Debug:        buildDebugOutput,
 	}
 	err := builder.Build(ctx, output)
 	if err != nil {

--- a/cmd/xcaddy/main.go
+++ b/cmd/xcaddy/main.go
@@ -30,10 +30,11 @@ import (
 )
 
 var (
-	caddyVersion = os.Getenv("CADDY_VERSION")
-	raceDetector = os.Getenv("XCADDY_RACE_DETECTOR") == "1"
-	skipBuild    = os.Getenv("XCADDY_SKIP_BUILD") == "1"
-	skipCleanup  = os.Getenv("XCADDY_SKIP_CLEANUP") == "1"
+	caddyVersion     = os.Getenv("CADDY_VERSION")
+	raceDetector     = os.Getenv("XCADDY_RACE_DETECTOR") == "1"
+	skipBuild        = os.Getenv("XCADDY_SKIP_BUILD") == "1"
+	skipCleanup      = os.Getenv("XCADDY_SKIP_CLEANUP") == "1"
+	buildDebugOutput = os.Getenv("XCADDY_DEBUG") == "1"
 )
 
 func main() {
@@ -55,12 +56,9 @@ func main() {
 
 func runBuild(ctx context.Context, args []string) error {
 	// parse the command line args... rather primitively
-	var (
-		argCaddyVersion, output string
-		buildDebugOutput        bool
-		plugins                 []xcaddy.Dependency
-		replacements            []xcaddy.Replace
-	)
+	var argCaddyVersion, output string
+	var plugins []xcaddy.Dependency
+	var replacements []xcaddy.Replace
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -96,9 +94,6 @@ func runBuild(ctx context.Context, args []string) error {
 			}
 			i++
 			output = args[i]
-
-		case "--debug":
-			buildDebugOutput = true
 
 		default:
 			if argCaddyVersion != "" {
@@ -236,6 +231,7 @@ func runDev(ctx context.Context, args []string) error {
 		RaceDetector: raceDetector,
 		SkipBuild:    skipBuild,
 		SkipCleanup:  skipCleanup,
+		Debug:        buildDebugOutput,
 	}
 	err = builder.Build(ctx, binOutput)
 	if err != nil {

--- a/cmd/xcaddy/main.go
+++ b/cmd/xcaddy/main.go
@@ -55,9 +55,13 @@ func main() {
 
 func runBuild(ctx context.Context, args []string) error {
 	// parse the command line args... rather primitively
-	var argCaddyVersion, output string
-	var plugins []xcaddy.Dependency
-	var replacements []xcaddy.Replace
+	var (
+		argCaddyVersion, output string
+		buildDebugVersion       bool
+		plugins                 []xcaddy.Dependency
+		replacements            []xcaddy.Replace
+	)
+
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--with":
@@ -93,6 +97,9 @@ func runBuild(ctx context.Context, args []string) error {
 			i++
 			output = args[i]
 
+		case "--debug":
+			buildDebugVersion = true
+
 		default:
 			if argCaddyVersion != "" {
 				return fmt.Errorf("missing flag; caddy version already set at %s", argCaddyVersion)
@@ -122,6 +129,7 @@ func runBuild(ctx context.Context, args []string) error {
 		RaceDetector: raceDetector,
 		SkipBuild:    skipBuild,
 		SkipCleanup:  skipCleanup,
+		Debug:        buildDebugVersion,
 	}
 	err := builder.Build(ctx, output)
 	if err != nil {

--- a/cmd/xcaddy/main.go
+++ b/cmd/xcaddy/main.go
@@ -59,7 +59,6 @@ func runBuild(ctx context.Context, args []string) error {
 	var argCaddyVersion, output string
 	var plugins []xcaddy.Dependency
 	var replacements []xcaddy.Replace
-
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--with":


### PR DESCRIPTION
**Fixes**: #61 

Allow building a debug output by setting `XCADDY_DEBUG=1` for `xcaddy` command.

**Examples**:

```bash
XCADDY_DEBUG=1 xcaddy build --with github.com/xxx/xxx=$(pwd)
XCADDY_DEBUG=1 xcaddy run
```