### PR TITLE
cmd: Add `xcaddy version` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
       run: |
         go build -trimpath -ldflags="-w -s" -v
 
+    - name: Output version
+      run: |
+        ${{ matrix.XCADDY_BIN_PATH }} version
+
     - name: Publish Build Artifact
       uses: actions/upload-artifact@v1
       with:
@@ -107,6 +111,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - name: Create 'xcaddy-build'
+        run: mkdir -p xcaddy-build
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,19 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
-    # So GoReleaser can generate the changelog properly
-    - name: Unshallowify the repo clone
-      run: git fetch --prune --unshallow
+    # Force fetch upstream tags -- because 65 minutes
+    # tl;dr: actions/checkout@v2 runs this line:
+    #   git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +ebc278ec98bb24f2852b61fde2a9bf2e3d83818b:refs/tags/
+    # which makes its own local lightweight tag, losing all the annotations in the process. Our earlier script ran:
+    #   git fetch --prune --unshallow
+    # which doesn't overwrite that tag because that would be destructive.
+    # Credit to @francislavoie for the investigation.
+    # https://github.com/actions/checkout/issues/290#issuecomment-680260080
+    - name: Force fetch upstream tags
+      run: git fetch --tags --force
 
     # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
     - name: Print Go version and environment
@@ -61,6 +70,16 @@ jobs:
     - name: Install Cloudsmith CLI
       run: pip install --upgrade cloudsmith-cli
 
+    - name: Validate commits and tag signatures
+      run: |
+        
+        # Import Matt Holt's key
+        curl 'https://github.com/mholt.gpg' | gpg --import
+
+        echo "Verifying the tag: ${{ steps.vars.outputs.version_tag }}"
+        # tags are only accepted if signed by Matt's key
+        git verify-tag "${{ steps.vars.outputs.version_tag }}" || exit 1
+
     - name: Cache the build cache
       uses: actions/cache@v2
       with:
@@ -68,6 +87,10 @@ jobs:
         key: ${{ runner.os }}-go${{ matrix.go }}-release-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go${{ matrix.go }}-release
+
+    - name: Create the 'caddy-build' dir for GoReleaser
+      run: |
+        mkdir -p xcaddy-build
 
     # GoReleaser will take care of publishing those artifacts into the release
     - name: Run GoReleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,19 @@
 before:
   hooks:
+    # The build is done in this particular way to build xcaddy in a designated directory named in .gitignore.
+    # This is so we can run goreleaser on tag without Git complaining of being dirty. The main.go in cmd/xcaddy directory 
+    # cannot be built within that directory due to changes necessary for the build causing Git to be dirty, which
+    # subsequently causes gorleaser to refuse running.
+    - mkdir -p xcaddy-build
+    - cp cmd/xcaddy/main.go xcaddy-build/main.go
+    - cp ./go.mod xcaddy-build/go.mod
+    - sed -i.bkp 's|github.com/caddyserver/xcaddy|xcaddy|g' ./xcaddy-build/go.mod
+    # GoReleaser doesn't seem to offer {{.Tag}} at this stage, so we have to embed it into the env
+    # so we run: TAG=$(git describe --abbrev=0) goreleaser release --rm-dist --skip-publish --skip-validate
+    - go mod edit -require=github.com/caddyserver/xcaddy@{{.Env.TAG}} ./xcaddy-build/go.mod
+    # as of Go 1.16, `go` commands no longer automatically change go.{mod,sum}. We now have to explicitly
+    # run `go mod tidy`. The `/bin/sh -c '...'` is because goreleaser can't find cd in PATH without shell invocation.
+    - /bin/sh -c 'cd ./xcaddy-build && go mod tidy'
     - go mod download
 
 builds:
@@ -7,7 +21,7 @@ builds:
   - CGO_ENABLED=0
   - GO111MODULE=on
   main: main.go
-  dir: ./cmd/xcaddy
+  dir: ./xcaddy-build
   binary: xcaddy
   goos:
   - darwin

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,4 +1,4 @@
-package main
+package xcaddycmd
 
 import (
 	"runtime"

--- a/cmd/xcaddy/main.go
+++ b/cmd/xcaddy/main.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	xcaddycmd "github.com/caddyserver/xcaddy/cmd"
+)
+
+func main() {
+	xcaddycmd.Main()
+}


### PR DESCRIPTION
Fix #22

It's not really useful to get Caddy's version when in dev mode anyways, and you can get full version information with `xcaddy list-modules --versions` if you _really_ need to... so "hiding" `caddy version` in dev mode to show `xcaddy`'s version instead seems totally fine.

I moved the `main.go` up a dir to match how Caddy does it for grabbing version information via having a level of indirection.

Sorry about the diff, `git` hates moving files when they have the same name. Please look at the first commit [`e6f588a`](https://github.com/caddyserver/xcaddy/pull/67/commits/e6f588a04ea819b21fc4c97298531f2ec24a05bf) on its own to see the _actual_ new code for grabbing the version.