### PR TITLE
ci: revert goreleaser workaround precereating caddy-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Create 'xcaddy-build'
-        run: mkdir -p xcaddy-build
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go${{ matrix.go }}-release
 
-    - name: Create the 'caddy-build' dir for GoReleaser
-      run: |
-        mkdir -p xcaddy-build
-
     # GoReleaser will take care of publishing those artifacts into the release
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
GoReleaser v0.177.0 fixes the issue, so the workaround is no longer needed.