### PR TITLE
fix: skip cleanup if build is skipped

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,7 @@ var (
 	caddyVersion     = os.Getenv("CADDY_VERSION")
 	raceDetector     = os.Getenv("XCADDY_RACE_DETECTOR") == "1"
 	skipBuild        = os.Getenv("XCADDY_SKIP_BUILD") == "1"
-	skipCleanup      = os.Getenv("XCADDY_SKIP_CLEANUP") == "1"
+	skipCleanup      = os.Getenv("XCADDY_SKIP_CLEANUP") == "1" || skipBuild
 	buildDebugOutput = os.Getenv("XCADDY_DEBUG") == "1"
 )
 


### PR DESCRIPTION
The env var `XCADDY_SKIP_BUILD` is supposed to imply `XCADDY_SKIP_CLEANUP`, but the implementation missed this detail. The `Builder#Build` method has `defer buildEnv.Close()`, which runs even on the early exit here:
https://github.com/caddyserver/xcaddy/blob/c7959560b56ec05306fd16f26d1b83e1f8272a40/builder.go#L80-L86

The `environment#Close` method does not know about `(Builder).SkipBuild`. We can overload the `skipCleanup` semantics because skipping build implies skipping cleanup.