### PR TITLE
run `go get -d` at the end of prepping new env

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -154,7 +154,10 @@ nextPlugin:
 		default:
 		}
 	}
-
+	err = env.execGoGet(ctx, "", "")
+	if err != nil {
+		return nil, err
+	}
 	log.Println("[INFO] Build environment ready")
 
 	return env, nil


### PR DESCRIPTION
For some reason, downloading the dependencies resolves away the ambiguity. It is not clear why that is and is currently being researched.

Fixes caddyserver/caddy#4331