### PR TITLE
Prevent main Caddy module from upgrading from adding a plugin

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -247,6 +247,7 @@ func (env environment) runCommand(ctx context.Context, cmd *exec.Cmd, timeout ti
 // Caddy module/version we're building against; this will prevent the
 // plugin module from causing the Caddy version to upgrade, if the plugin
 // version requires a newer version of Caddy.
+// See https://github.com/caddyserver/xcaddy/issues/54
 func (env environment) execGoGet(ctx context.Context, modulePath, moduleVersion, caddyModulePath, caddyVersion string) error {
 	mod := modulePath
 	if moduleVersion != "" {
@@ -257,9 +258,9 @@ func (env environment) execGoGet(ctx context.Context, modulePath, moduleVersion,
 		caddy += "@" + caddyVersion
 	}
 
-	// for some reason, using an empty string as an additional
-	// argument to "go get" breaks the command, so we're using
-	// an if statement to avoid it.
+	// using an empty string as an additional argument to "go get"
+	// breaks the command since it treats the empty string as a
+	// distinct argument, so we're using an if statement to avoid it.
 	var cmd *exec.Cmd
 	if caddy != "" {
 		cmd = env.newCommand("go", "get", "-d", "-v", mod, caddy)

--- a/environment.go
+++ b/environment.go
@@ -128,7 +128,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 
 	// pin versions by populating go.mod, first for Caddy itself and then plugins
 	log.Println("[INFO] Pinning versions")
-	err = env.execGoGet(ctx, caddyModulePath, env.caddyVersion)
+	err = env.execGoGet(ctx, caddyModulePath, env.caddyVersion, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,8 @@ nextPlugin:
 				continue nextPlugin
 			}
 		}
-		err = env.execGoGet(ctx, p.PackagePath, p.Version)
+		// also pass the Caddy version to prevent it from being upgraded
+		err = env.execGoGet(ctx, p.PackagePath, p.Version, caddyModulePath, env.caddyVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -154,12 +155,16 @@ nextPlugin:
 		default:
 		}
 	}
-	err = env.execGoGet(ctx, "", "")
+
+	// doing an empty "go get -d" can potentially resolve some
+	// ambiguities introduced by one of the plugins;
+	// see https://github.com/caddyserver/xcaddy/pull/92
+	err = env.execGoGet(ctx, "", "", "", "")
 	if err != nil {
 		return nil, err
 	}
-	log.Println("[INFO] Build environment ready")
 
+	log.Println("[INFO] Build environment ready")
 	return env, nil
 }
 
@@ -237,12 +242,31 @@ func (env environment) runCommand(ctx context.Context, cmd *exec.Cmd, timeout ti
 	}
 }
 
-func (env environment) execGoGet(ctx context.Context, modulePath, moduleVersion string) error {
+// execGoGet runs "go get -d -v" with the given module/version as an argument.
+// Also allows passing in a second module/version pair, meant to be the main
+// Caddy module/version we're building against; this will prevent the
+// plugin module from causing the Caddy version to upgrade, if the plugin
+// version requires a newer version of Caddy.
+func (env environment) execGoGet(ctx context.Context, modulePath, moduleVersion, caddyModulePath, caddyVersion string) error {
 	mod := modulePath
 	if moduleVersion != "" {
 		mod += "@" + moduleVersion
 	}
-	cmd := env.newCommand("go", "get", "-d", "-v", mod)
+	caddy := caddyModulePath
+	if caddyVersion != "" {
+		caddy += "@" + caddyVersion
+	}
+
+	// for some reason, using an empty string as an additional
+	// argument to "go get" breaks the command, so we're using
+	// an if statement to avoid it.
+	var cmd *exec.Cmd
+	if caddy != "" {
+		cmd = env.newCommand("go", "get", "-d", "-v", mod, caddy)
+	} else {
+		cmd = env.newCommand("go", "get", "-d", "-v", mod)
+	}
+
 	return env.runCommand(ctx, cmd, env.timeoutGoGet)
 }
 


### PR DESCRIPTION
Fixes #54

For example:

```
$ xcaddy build v2.3.0 --with github.com/caddy-dns/cloudflare
...
2022/04/06 01:54:25 [INFO] Initializing Go module
2022/04/06 01:54:25 [INFO] exec (timeout=10s): go mod init caddy
2022/04/06 01:54:26 [INFO] Pinning versions
2022/04/06 01:54:26 [INFO] exec (timeout=0s): go get -d -v github.com/caddyserver/caddy/v2@v2.3.0
...

2022/04/06 01:54:27 [INFO] exec (timeout=0s): go get -d -v github.com/caddy-dns/cloudflare github.com/caddyserver/caddy/v2@v2.3.0
go: github.com/caddy-dns/cloudflare@upgrade (v0.0.0-20210607183747-91cf700356a1) requires github.com/caddyserver/caddy/v2@v2.4.0, not github.com/caddyserver/caddy/v2@v2.3.0
2022/04/06 01:54:28 [FATAL] exit status 1
```

The key being that the `go get` to add the `cloudflare` plugin _also_ specifies the Caddy module, which puts a constraint that the Caddy module should not upgrade past that version from pulling in the plugin.

This means that some builds that would have previously worked might fail now, but I think this is least-surprise, because it's _weird_ that if you specify a version of Caddy that it would get upgraded higher because of a plugin.

This can be solved by specifying a version of the plugin that _does_ build with the older version of Caddy specified:

```
$ xcaddy build v2.3.0 --with github.com/caddy-dns/cloudflare@eda8e5aa22232e9c279b0df7531f20c331b331c6
...
2022/04/06 02:12:26 [INFO] Initializing Go module
2022/04/06 02:12:26 [INFO] exec (timeout=10s): go mod init caddy
go: creating new go.mod: module caddy
go: to add module requirements and sums:
        go mod tidy
2022/04/06 02:12:26 [INFO] Pinning versions
2022/04/06 02:12:26 [INFO] exec (timeout=0s): go get -d -v github.com/caddyserver/caddy/v2@v2.3.0
...

2022/04/06 02:12:27 [INFO] exec (timeout=0s): go get -d -v github.com/caddy-dns/cloudflare@eda8e5aa22232e9c279b0df7531f20c331b331c6 github.com/caddyserver/caddy/v2@v2.3.0
go: added github.com/caddy-dns/cloudflare v0.0.0-20210105070211-eda8e5aa2223
go: added github.com/libdns/cloudflare v0.0.0-20200528144945-97886e7873b1
2022/04/06 02:12:29 [INFO] exec (timeout=0s): go get -d -v
2022/04/06 02:12:31 [INFO] Build environment ready
2022/04/06 02:12:31 [INFO] Building Caddy
2022/04/06 02:12:31 [INFO] exec (timeout=0s): go mod tidy
2022/04/06 02:12:31 [INFO] exec (timeout=0s): go build -o ./caddy -ldflags -w -s -trimpath
2022/04/06 02:12:34 [INFO] Build complete: ./caddy
```