### PR TITLE
Log out main.go contents, update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # Used as inspiration: https://github.com/mvdan/github-actions-golang
 
-name: Cross-Platform Tests
+name: Tests
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ '1.16', '1.17' ]
+        go: [ '1.17', '1.18' ]
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # XCADDY_BIN_PATH: the path to the compiled xcaddy binary, for artifact publishing
@@ -39,12 +39,12 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Print Go version and environment
       id: vars
@@ -92,25 +92,12 @@ jobs:
       run: |
         go test -v -coverprofile="cover-profile.out" -short -race ./...
 
-  # From https://github.com/reviewdog/action-golangci-lint
-  golangci-lint:
-    name: runner / golangci-lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Run golangci-lint
-        uses: reviewdog/action-golangci-lint@v1
-        # uses: docker://reviewdog/action-golangci-lint:v1 # pre-build docker image
-        with:
-          github_token: ${{ secrets.github_token }}
-
   goreleaser-check:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  # From https://github.com/golangci/golangci-lint-action
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.44
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        go: [ '1.17' ]
+        go: [ '1.18' ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ _gitignore/
 # build artifacts
 cmd/xcaddy/xcaddy
 cmd/xcaddy/xcaddy.exe
+cmd/xcaddy/caddy
+cmd/xcaddy/caddy.exe
 
 # mac
 .DS_Store

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,3 +40,7 @@ issues:
     - text: "G204" # G204: Audit use of command execution
       linters:
         - gosec
+    # we're writing out the main.go to a temp dir, not sensitive
+    - text: "G306" # G306: Expect WriteFile permissions to be 0600 or less (gosec)
+      linters:
+        - gosec

--- a/environment.go
+++ b/environment.go
@@ -230,7 +230,7 @@ func (env environment) runCommand(ctx context.Context, cmd *exec.Cmd, timeout ti
 		// to the child process, so wait for it to die
 		select {
 		case <-time.After(15 * time.Second):
-			cmd.Process.Kill()
+			_ = cmd.Process.Kill()
 		case <-cmdErrChan:
 		}
 		return ctx.Err()

--- a/environment.go
+++ b/environment.go
@@ -83,7 +83,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 
 	// write the main module file to temporary folder
 	mainPath := filepath.Join(tempFolder, "main.go")
-	log.Printf("[INFO] Writing main module: %s", mainPath)
+	log.Printf("[INFO] Writing main module: %s\n%s", mainPath, buf.Bytes())
 	err = ioutil.WriteFile(mainPath, buf.Bytes(), 0644)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I thought it would be helpful to log out the generated `main.go` in the logs, because sometimes it's nice to use the xcaddy logs as a report to Go upstream when we have some strange issues with building. Makes it easier to take the logs, tidy them up as reproduction steps, and post them somewhere.

Example:

```
$ xcaddy build --with github.com/caddy-dns/cloudflare
2022/04/06 16:38:10 [INFO] Temporary folder: /tmp/buildenv_2022-04-06-1638.383429390
2022/04/06 16:38:10 [INFO] Writing main module: /tmp/buildenv_2022-04-06-1638.383429390/main.go
package main

import (
	caddycmd "github.com/caddyserver/caddy/v2/cmd"

	// plug in Caddy modules here
	_ "github.com/caddyserver/caddy/v2/modules/standard"
	_ "github.com/caddy-dns/cloudflare"
)

func main() {
	caddycmd.Main()
}
2022/04/06 16:38:10 [INFO] Initializing Go module
2022/04/06 16:38:10 [INFO] exec (timeout=10s): /usr/local/go/bin/go mod init caddy
```