### PR TITLE
Enable overriding build flags from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Because the subcommands and flags are constrained to benefit rapid plugin protot
 - `XCADDY_SKIP_BUILD=1` causes xcaddy to not compile the program, it is used in conjunction with build tools such as [GoReleaser](https://goreleaser.com). Implies `XCADDY_SKIP_CLEANUP=1`.
 - `XCADDY_SKIP_CLEANUP=1` causes xcaddy to leave build artifacts on disk after exiting.
 - `XCADDY_WHICH_GO` sets the go command to use when for example more then 1 version of go is installed.
+- `XCADDY_GO_BUILD_FLAGS` overrides default build arguments. Supports Unix-style shell quoting, for example: XCADDY_GO_BUILD_FLAGS="-ldflags '-w s'".
 ---
 
 &copy; 2020 Matthew Holt

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,6 +40,7 @@ var (
 	skipBuild        = os.Getenv("XCADDY_SKIP_BUILD") == "1"
 	skipCleanup      = os.Getenv("XCADDY_SKIP_CLEANUP") == "1" || skipBuild
 	buildDebugOutput = os.Getenv("XCADDY_DEBUG") == "1"
+	buildFlags       = os.Getenv("XCADDY_GO_BUILD_FLAGS")
 )
 
 func Main() {
@@ -134,6 +135,7 @@ func runBuild(ctx context.Context, args []string) error {
 		SkipBuild:    skipBuild,
 		SkipCleanup:  skipCleanup,
 		Debug:        buildDebugOutput,
+		BuildFlags:   buildFlags,
 	}
 	err := builder.Build(ctx, output)
 	if err != nil {

--- a/environment.go
+++ b/environment.go
@@ -98,6 +98,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 		tempFolder:      tempFolder,
 		timeoutGoGet:    b.TimeoutGet,
 		skipCleanup:     b.SkipCleanup,
+		buildFlags:      b.BuildFlags,
 	}
 
 	// initialize the go module
@@ -177,6 +178,7 @@ type environment struct {
 	tempFolder      string
 	timeoutGoGet    time.Duration
 	skipCleanup     bool
+	buildFlags      string
 }
 
 // Close cleans up the build environment, including deleting

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/caddyserver/xcaddy
 
 go 1.14
 
-require github.com/Masterminds/semver/v3 v3.1.1
+require (
+	github.com/Masterminds/semver/v3 v3.1.1
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=


### PR DESCRIPTION
Add environment variable

 XCADDY_GOBUILDFLAGS

to override default build arguments from environment (close #102).

To support flags with variable arguments Unix-style quoting is supported.