### PR TITLE
Inject `XCADDY_GO_BUILD_FLAGS` through `go` operations (#102)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/caddyserver/xcaddy/internal/utils"
-	"github.com/google/shlex"
 )
 
 // Builder can produce a custom Caddy build with the
@@ -117,14 +116,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 		// support dlv
 		cmd.Args = append(cmd.Args, "-gcflags", "all=-N -l")
 	} else {
-		if b.BuildFlags != "" {
-			// override build flags from environment if given
-			flags, err := shlex.Split(b.BuildFlags)
-			if err != nil {
-				log.Fatalf("[FATAL] Splitting arguments failed: %s", b.BuildFlags)
-			}
-			cmd.Args = append(cmd.Args, flags...)
-		} else {
+		if buildEnv.buildFlags == "" {
 			cmd.Args = append(cmd.Args,
 				"-ldflags", "-w -s", // trim debug symbols
 				"-trimpath",

--- a/builder.go
+++ b/builder.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/caddyserver/xcaddy/internal/utils"
 )
 
 // Builder can produce a custom Caddy build with the
@@ -103,13 +102,13 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	log.Println("[INFO] Building Caddy")
 
 	// tidy the module to ensure go.mod and go.sum are consistent with the module prereq
-	tidyCmd := buildEnv.newCommand(utils.GetGo(), "mod", "tidy")
+	tidyCmd := buildEnv.newGoCommand("mod", "tidy")
 	if err := buildEnv.runCommand(ctx, tidyCmd, b.TimeoutGet); err != nil {
 		return err
 	}
 
 	// compile
-	cmd := buildEnv.newCommand(utils.GetGo(), "build",
+	cmd := buildEnv.newGoCommand("build",
 		"-o", absOutputFile,
 	)
 	if b.Debug {

--- a/environment.go
+++ b/environment.go
@@ -104,7 +104,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 
 	// initialize the go module
 	log.Println("[INFO] Initializing Go module")
-	cmd := env.newCommand(utils.GetGo(), "mod", "init")
+	cmd := env.newGoCommand("mod", "init")
 	cmd.Args = append(cmd.Args, "caddy")
 	err = env.runCommand(ctx, cmd, 10*time.Second)
 	if err != nil {
@@ -115,7 +115,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 	replaced := make(map[string]string)
 	for _, r := range b.Replacements {
 		log.Printf("[INFO] Replace %s => %s", r.Old.String(), r.New.String())
-		cmd := env.newCommand(utils.GetGo(), "mod", "edit",
+		cmd := env.newGoCommand("mod", "edit",
 			"-replace", fmt.Sprintf("%s=%s", r.Old.Param(), r.New.Param()))
 		err := env.runCommand(ctx, cmd, 10*time.Second)
 		if err != nil {
@@ -194,8 +194,8 @@ func (env environment) Close() error {
 	return os.RemoveAll(env.tempFolder)
 }
 
-func (env environment) newCommand(command string, args ...string) *exec.Cmd {
-	cmd := exec.Command(command, args...)
+func (env environment) newGoCommand(args ...string) *exec.Cmd {
+	cmd := exec.Command(utils.GetGo(), args...)
 	cmd.Dir = env.tempFolder
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -276,7 +276,7 @@ func (env environment) execGoGet(ctx context.Context, modulePath, moduleVersion,
 		caddy += "@" + caddyVersion
 	}
 
-	cmd := env.newCommand(utils.GetGo(), "get", "-d", "-v")
+	cmd := env.newGoCommand("get", "-d", "-v")
 	// using an empty string as an additional argument to "go get"
 	// breaks the command since it treats the empty string as a
 	// distinct argument, so we're using an if statement to avoid it.


### PR DESCRIPTION
Commit 47f9ded5d83ca8e701852ca7ad57cd3453e6f988 is not sufficient alone to
ensure that all go modules are installed with write bit set because 'go mod'
or 'go get' might install submodules of other modules as read-only.

If set, the environment variable appends '-modcacherw' to go mod and go get
to ensure that submodules of other modules have write access.