### PR TITLE
Enforce compatibility resolution go 1.17 (#111)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -105,6 +105,10 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 
 	// tidy the module to ensure go.mod and go.sum are consistent with the module prereq
 	tidyCmd := buildEnv.newCommand(utils.GetGo(), "mod", "tidy")
+	// go introduced module graph pruning in version 1.17 which requires compatibility resolution
+	if strings.HasPrefix(runtime.Version(), "go1.17") {
+		tidyCmd.Args = append(tidyCmd.Args, "-compat=1.17")
+	}
 	if err := buildEnv.runCommand(ctx, tidyCmd, b.TimeoutGet); err != nil {
 		return err
 	}


### PR DESCRIPTION
Go 1.17 introduced module graph pruning which might cause 'go mod tidy'
to fail when it faces two imports of the same module. Pass compatibility
version to advice go mod how to resolve module dependencies.