### PR TITLE
core: add `XCADDY_GO_MOD_FLAGS` env var to allow passing custom `go mod` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ Because the subcommands and flags are constrained to benefit rapid plugin protot
 - `XCADDY_SKIP_BUILD=1` causes xcaddy to not compile the program, it is used in conjunction with build tools such as [GoReleaser](https://goreleaser.com). Implies `XCADDY_SKIP_CLEANUP=1`.
 - `XCADDY_SKIP_CLEANUP=1` causes xcaddy to leave build artifacts on disk after exiting.
 - `XCADDY_WHICH_GO` sets the go command to use when for example more then 1 version of go is installed.
-- `XCADDY_GO_BUILD_FLAGS` overrides default build arguments. Supports Unix-style shell quoting, for example: XCADDY_GO_BUILD_FLAGS="-ldflags '-w s'".
+- `XCADDY_GO_BUILD_FLAGS` overrides default build arguments. Supports Unix-style shell quoting, for example: XCADDY_GO_BUILD_FLAGS="-ldflags '-w s'". The provided flags are applied to `go` commands: build, clean, get, install, list, run, and test
+- `XCADDY_GO_MOD_FLAGS` overrides default `go mod` arguments. Supports Unix-style shell quoting.
+
 ---
 
 &copy; 2020 Matthew Holt

--- a/builder.go
+++ b/builder.go
@@ -45,6 +45,7 @@ type Builder struct {
 	SkipBuild    bool          `json:"skip_build,omitempty"`
 	Debug        bool          `json:"debug,omitempty"`
 	BuildFlags   string        `json:"build_flags,omitempty"`
+	ModFlags     string        `json:"mod_flags,omitempty"`
 }
 
 // Build builds Caddy at the configured version with the
@@ -102,13 +103,13 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	log.Println("[INFO] Building Caddy")
 
 	// tidy the module to ensure go.mod and go.sum are consistent with the module prereq
-	tidyCmd := buildEnv.newGoCommand("mod", "tidy")
+	tidyCmd := buildEnv.newGoModCommand("tidy")
 	if err := buildEnv.runCommand(ctx, tidyCmd, b.TimeoutGet); err != nil {
 		return err
 	}
 
 	// compile
-	cmd := buildEnv.newGoCommand("build",
+	cmd := buildEnv.newGoBuildCommand("build",
 		"-o", absOutputFile,
 	)
 	if b.Debug {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ var (
 	skipCleanup      = os.Getenv("XCADDY_SKIP_CLEANUP") == "1" || skipBuild
 	buildDebugOutput = os.Getenv("XCADDY_DEBUG") == "1"
 	buildFlags       = os.Getenv("XCADDY_GO_BUILD_FLAGS")
+	modFlags         = os.Getenv("XCADDY_GO_MOD_FLAGS")
 )
 
 func Main() {
@@ -136,6 +137,7 @@ func runBuild(ctx context.Context, args []string) error {
 		SkipCleanup:  skipCleanup,
 		Debug:        buildDebugOutput,
 		BuildFlags:   buildFlags,
+		ModFlags:     modFlags,
 	}
 	err := builder.Build(ctx, output)
 	if err != nil {


### PR DESCRIPTION
This is a follow-up to #110, as mentioned in https://github.com/caddyserver/xcaddy/pull/110#pullrequestreview-1074662198.

CC/ @akeskimo 