### PR TITLE
fix: xcaddy run on windows with go 1.19

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -164,10 +164,11 @@ func runBuild(ctx context.Context, args []string) error {
 }
 
 func getCaddyOutputFile() string {
+	f := "." + string(filepath.Separator) + "caddy"
 	if runtime.GOOS == "windows" {
-		return "caddy.exe"
+		f += ".exe"
 	}
-	return "." + string(filepath.Separator) + "caddy"
+	return f
 }
 
 func runDev(ctx context.Context, args []string) error {


### PR DESCRIPTION
Hi @mholt,
you were right #116 is a windows specific problem. I found this more detailed issue https://github.com/golang/go/issues/43724 were the reasons for the change are described.

> To recap how we got here, the fundamental problem is that lots of Go programs do things like exec.Command("prog") and expect that prog will come from a system directory listed in the PATH. It is a surprise and in some cases a security problem that on Windows prog will be taken from dot instead when prog.exe (or prog.bat, prog.com, ...) exists.

Because there is a special case in [getCaddyOutputFile](https://github.com/caddyserver/xcaddy/blob/0bd3c1dfd5c43841f23a198695aa1dee6488eb7c/cmd/main.go#L166) for windows xcaddy does exactly that, but it really wants to use the binary from the current directory.

> Programs that want to require the current directory to be used (ignoring PATH) can change "prog" to "./prog" (that works on both Unix and Windows systems). This change ("prog" to "./prog") is compatible with older versions of os/exec.

For me `run` and `build` also works without the windows special case, but #33 explicitly added the `.exe` ending so I kept it.

Closes #116 