### PR TITLE
Add support for setcap from `build` command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,9 +34,9 @@ builds:
   - s390x
   - ppc64le
   goarm:
-  - 5
-  - 6
-  - 7
+  - "5"
+  - "6"
+  - "7"
   ignore:
     - goos: darwin
       goarch: arm
@@ -54,7 +54,7 @@ builds:
       goarch: s390x
     - goos: freebsd
       goarch: arm
-      goarm: 5
+      goarm: "5"
   flags:
   - -trimpath
   ldflags:
@@ -64,8 +64,15 @@ archives:
   - format_overrides:
       - goos: windows
         format: zip
-    replacements:
-      darwin: mac
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- if eq .Os "darwin" }}mac{{ else }}{{ .Os }}{{ end }}_
+      {{- .Arch }}
+      {{- with .Arm }}v{{ . }}{{ end }}
+      {{- with .Mips }}_{{ . }}{{ end }}
+      {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
+
 checksum:
   algorithm: sha512
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Because the subcommands and flags are constrained to benefit rapid plugin protot
 - `CADDY_VERSION` sets the version of Caddy to build.
 - `XCADDY_RACE_DETECTOR=1` enables the Go race detector in the build.
 - `XCADDY_DEBUG=1` enables the DWARF debug information in the build.
-- `XCADDY_SETCAP=1` will run `sudo setcap cap_net_bind_service=+ep` on the built binary. By default, `sudo` will be used; set `XCADDY_SETCAP_NO_SUDO=1` if running the build as root user.
+- `XCADDY_SETCAP=1` will run `sudo setcap cap_net_bind_service=+ep` on the resulting binary. By default, the `sudo` command will be used if it is found; set `XCADDY_SUDO=0` to avoid using `sudo` if necessary.
 - `XCADDY_SKIP_BUILD=1` causes xcaddy to not compile the program, it is used in conjunction with build tools such as [GoReleaser](https://goreleaser.com). Implies `XCADDY_SKIP_CLEANUP=1`.
 - `XCADDY_SKIP_CLEANUP=1` causes xcaddy to leave build artifacts on disk after exiting.
 - `XCADDY_WHICH_GO` sets the go command to use when for example more then 1 version of go is installed.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Because the subcommands and flags are constrained to benefit rapid plugin protot
 - `CADDY_VERSION` sets the version of Caddy to build.
 - `XCADDY_RACE_DETECTOR=1` enables the Go race detector in the build.
 - `XCADDY_DEBUG=1` enables the DWARF debug information in the build.
-- `XCADDY_SETCAP=1` will run `sudo setcap cap_net_bind_service=+ep` on the temporary binary before running it when in dev mode.
+- `XCADDY_SETCAP=1` will run `sudo setcap cap_net_bind_service=+ep` on the built binary. By default, `sudo` will be used; set `XCADDY_SETCAP_NO_SUDO=1` if running the build as root user.
 - `XCADDY_SKIP_BUILD=1` causes xcaddy to not compile the program, it is used in conjunction with build tools such as [GoReleaser](https://goreleaser.com). Implies `XCADDY_SKIP_CLEANUP=1`.
 - `XCADDY_SKIP_CLEANUP=1` causes xcaddy to leave build artifacts on disk after exiting.
 - `XCADDY_WHICH_GO` sets the go command to use when for example more then 1 version of go is installed.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -268,7 +268,7 @@ func setcapIfRequested(output string) error {
 
 	// check if sudo isn't available, or we were instructed not to use it
 	_, sudoNotFound := exec.LookPath("sudo")
-	skipSudo := sudoNotFound != nil || os.Getenv("XCADDY_SETCAP_NO_SUDO") == "1"
+	skipSudo := sudoNotFound != nil || os.Getenv("XCADDY_SUDO") == "0"
 
 	var cmd *exec.Cmd
 	if skipSudo {


### PR DESCRIPTION
Fix #128 

Haven't tested this yet. But it should be straight-forwards.

One detail I'm not sure how to handle is `sudo`. The `runDev` version of the code uses `sudo` by default, and that seems reasonable since a dev account is _probably_ a regular user and not root. But this purpose of the `runBuild` version is to run in Docker, which will be running as root. So having `sudo` would fail. I just added another env var to cover that case.

Is there a better way to automatically detect whether `sudo` should be used? I'm not sure how that should be done from Go.