### PR TITLE
builder: Ignore tidy errors

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -107,7 +107,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	log.Println("[INFO] Building Caddy")
 
 	// tidy the module to ensure go.mod and go.sum are consistent with the module prereq
-	tidyCmd := buildEnv.newGoModCommand(ctx, "tidy")
+	tidyCmd := buildEnv.newGoModCommand(ctx, "tidy", "-e")
 	if err := buildEnv.runCommand(ctx, tidyCmd); err != nil {
 		return err
 	}


### PR DESCRIPTION
See the conversation in the gophers slack: https://gophers.slack.com/archives/C9BMAAFFB/p1683645084906259?thread_ts=1683329744.706999&cid=C9BMAAFFB

Help doc for `-e`:

> The -e flag causes tidy to attempt to proceed despite errors encountered while loading packages.

The effect is that some errors might be reported in stderr, but if non-critical it should ideally be able to push forwards and still complete tidying. If there's any more serious errors, `go build` should error out.