### PR TITLE
cmd: add synthetic command `validate-interfaces`

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -45,6 +45,15 @@ type Builder struct {
 	Debug        bool          `json:"debug,omitempty"`
 	BuildFlags   string        `json:"build_flags,omitempty"`
 	ModFlags     string        `json:"mod_flags,omitempty"`
+
+	// Experimental: Inject extra imports into the build. These
+	// imports are to add Go modules that may be needed in the
+	// Prequels.
+	ExtraImports []string
+	// Experimental: Inject extra code before running Caddy's `main`.
+	// If any of the prequels requires an import, it's you responsibility
+	// to add the import to the ExtraImports slice.
+	Prequels []string
 }
 
 // Build builds Caddy at the configured version with the


### PR DESCRIPTION
The command is injected when running xcaddy with one of Caddy's commands, though `validate-interfaces` does not exist in Caddy itself. This is useful for [guest modules](https://caddyserver.com/docs/extending-caddy) developers to validate their implementation meets the expectation of the host module. Developers who introduce new caddy namespaces and want to participate in the validation process may include code as such in their `init`:

```
RegisterType("their.new.namespace", []interface{}{(*Interface1)(nil), (*Interface2)(nil)})
```

There's dependency on caddyserver/caddy#4838 because the Caddy executable built for the development process expects a version of Caddy that contains certain functions, namely `caddy.ConformsToNamespace`. I'm not sure if this will break any workflow. We can brainstorm an idea to conditionally inject it, but I can't think of something now.

With this addition, the developer of a Caddy module can run `xcaddy validate-interfaces` to have a custom Caddy built to receive a message of either `All modules conform to their namespaces.` or a spit-out of the interface they're missing.

Perhaps `validate-types` is a better command name? 🤔 