### PR TITLE
add ".exe" when cross compiling for windows

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -194,7 +194,8 @@ func runBuild(ctx context.Context, args []string) error {
 
 func getCaddyOutputFile() string {
 	f := "." + string(filepath.Separator) + "caddy"
-	if runtime.GOOS == "windows" {
+	// compiling on or for Windows, use .exe extension
+	if runtime.GOOS == "windows" || os.Getenv("GOOS") == "windows" {
 		f += ".exe"
 	}
 	return f

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ package xcaddycmd
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -194,8 +195,8 @@ func runBuild(ctx context.Context, args []string) error {
 
 func getCaddyOutputFile() string {
 	f := "." + string(filepath.Separator) + "caddy"
-	// compiling on or for Windows, use .exe extension
-	if runtime.GOOS == "windows" || os.Getenv("GOOS") == "windows" {
+	// compiling for Windows or compiling on windows without setting GOOS, use .exe extension
+	if cmp.Or(os.Getenv("GOOS"), runtime.GOOS) == "windows" {
 		f += ".exe"
 	}
 	return f

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,7 +16,6 @@ package xcaddycmd
 
 import (
 	"bytes"
-	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -196,7 +195,7 @@ func runBuild(ctx context.Context, args []string) error {
 func getCaddyOutputFile() string {
 	f := "." + string(filepath.Separator) + "caddy"
 	// compiling for Windows or compiling on windows without setting GOOS, use .exe extension
-	if cmp.Or(os.Getenv("GOOS"), runtime.GOOS) == "windows" {
+	if os.Getenv("GOOS") == "windows" || (os.Getenv("GOOS") == "" && runtime.GOOS == "windows") {
 		f += ".exe"
 	}
 	return f

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caddyserver/xcaddy
 
-go 1.22
+go 1.14
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caddyserver/xcaddy
 
-go 1.14
+go 1.22
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
Previously ".exe" will be added automatically when on windows, but not when cross compiling.