### PR TITLE
bug: fix regression preventing `-trimpath` and trim of debug symbols

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -131,7 +131,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 			cmd.Args = append(cmd.Args,
 				"-ldflags", "-w -s", // trim debug symbols
 				"-trimpath",
-				"-tags nobadger",
+				"-tags", "nobadger",
 			)
 		}
 	}

--- a/builder.go
+++ b/builder.go
@@ -131,6 +131,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 			cmd.Args = append(cmd.Args,
 				"-ldflags", "-w -s", // trim debug symbols
 				"-trimpath",
+				"-tags nobadger",
 			)
 		}
 	}

--- a/environment.go
+++ b/environment.go
@@ -127,7 +127,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 		tempFolder:      tempFolder,
 		timeoutGoGet:    b.TimeoutGet,
 		skipCleanup:     b.SkipCleanup,
-		buildFlags:      strings.TrimSpace("-tags nobadger " + b.BuildFlags),
+		buildFlags:      b.BuildFlags,
 		modFlags:        b.ModFlags,
 	}
 


### PR DESCRIPTION
Fixes #181 

I haven't validated it yet. I might need to split `-tags` from `nobadger`.