### PR TITLE
fix variable environment extraction

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/caddyserver/xcaddy/internal/utils"
 )
 
 // Builder can produce a custom Caddy build with the
@@ -76,10 +77,10 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 
 	// set some defaults from the environment, if applicable
 	if b.OS == "" {
-		b.OS = os.Getenv("GOOS")
+		b.OS = utils.GetGOOS()
 	}
 	if b.Arch == "" {
-		b.Arch = os.Getenv("GOARCH")
+		b.Arch = utils.GetGOARCH()
 	}
 	if b.ARM == "" {
 		b.ARM = os.Getenv("GOARM")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -167,6 +167,11 @@ func runBuild(ctx context.Context, args []string) error {
 		log.Fatalf("[FATAL] %v", err)
 	}
 
+	// done if we're skipping the build
+	if builder.SkipBuild {
+		return nil
+	}
+
 	// if requested, run setcap to allow binding to low ports
 	err = setcapIfRequested(output)
 	if err != nil {
@@ -174,7 +179,7 @@ func runBuild(ctx context.Context, args []string) error {
 	}
 
 	// prove the build is working by printing the version
-	if runtime.GOOS == os.Getenv("GOOS") && runtime.GOARCH == os.Getenv("GOARCH") {
+	if runtime.GOOS == utils.GetGOOS() && runtime.GOARCH == utils.GetGOARCH() {
 		if !filepath.IsAbs(output) {
 			output = "." + string(filepath.Separator) + output
 		}
@@ -195,7 +200,7 @@ func runBuild(ctx context.Context, args []string) error {
 func getCaddyOutputFile() string {
 	f := "." + string(filepath.Separator) + "caddy"
 	// compiling for Windows or compiling on windows without setting GOOS, use .exe extension
-	if os.Getenv("GOOS") == "windows" || (os.Getenv("GOOS") == "" && runtime.GOOS == "windows") {
+	if utils.GetGOOS() == "windows" {
 		f += ".exe"
 	}
 	return f

--- a/internal/utils/environment.go
+++ b/internal/utils/environment.go
@@ -1,6 +1,9 @@
 package utils
 
-import "os"
+import (
+	"os"
+	"runtime"
+)
 
 // GetGo returns the go executable to use depending on what
 // is set in the XCADDY_WHICH_GO environment variable.
@@ -10,4 +13,22 @@ func GetGo() string {
 		return "go"
 	}
 	return g
+}
+
+// GetGOOS returns the compilation target OS
+func GetGOOS() string {
+	o := os.Getenv("GOOS")
+	if o == "" {
+		return runtime.GOOS
+	}
+	return o
+}
+
+// GetGOARCH returns the compilation target architecture
+func GetGOARCH() string {
+	a := os.Getenv("GOARCH")
+	if a == "" {
+		return runtime.GOARCH
+	}
+	return a
 }


### PR DESCRIPTION
As said on Slack, some of the environmental variables are missing when building but they won't impact the build result because golang automatically fallbacks to `go env`.

No further action when build is skipped.