### PR TITLE
embed: turn source path to absolute for error-less copy

### DIFF
--- a/io.go
+++ b/io.go
@@ -12,6 +12,7 @@ import (
 
 // copy recursively copies src into dst with src's file modes.
 func copy(src, dst string) error {
+	src, _ = filepath.Abs(src)
 	src = filepath.ToSlash(src)
 	dst = filepath.ToSlash(dst)
 	log.Printf("[INFO] copying files: src=%s dest=%s", src, dst)


### PR DESCRIPTION
I'm not sure if it has always been this way, but apparently using `--embed` with relative path results in an error. I figure turning the path into its absolute form avoids any embedding issue or confusion in tooling.