### PR TITLE
docs: Add `embedded` filesystem declaration to `--embed` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ You may embed directories into the Caddy executable and serve them from the `emb
 $ xcaddy build --embed foo:./sites/foo --embed bar:./sites/bar
 $ cat Caddyfile
 {
+    # You must declare a custom filesystem using the `embedded` module.
+    # The first argument to `filesystem` is an arbitrary identifier
+    # that will also be passed to `fs` directives.
     filesystem my_embeds embedded
 }
 

--- a/README.md
+++ b/README.md
@@ -116,26 +116,26 @@ This allows you to hack on Caddy core (and optionally plug in extra modules at t
 
 ---
 
-You may embed directories into the Caddy executable and serve them from the `embedded` filesystem:
+You may embed directories into the Caddy executable and serve them from the `embedded` filesystem module:
 
 ```
 $ xcaddy build --embed foo:./sites/foo --embed bar:./sites/bar
 $ cat Caddyfile
 {
-    filesystem embedded embedded
+    filesystem my_embeds embedded
 }
 
 foo.localhost {
 	root * /foo
 	file_server {
-		fs embedded
+		fs my_embeds
 	}
 }
 
 bar.localhost {
 	root * /bar
 	file_server {
-		fs embedded
+		fs my_embeds
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -116,11 +116,15 @@ This allows you to hack on Caddy core (and optionally plug in extra modules at t
 
 ---
 
-You may embed directories into the Caddy executable:
+You may embed directories into the Caddy executable and serve them from the `embedded` filesystem:
 
 ```
 $ xcaddy build --embed foo:./sites/foo --embed bar:./sites/bar
 $ cat Caddyfile
+{
+    filesystem embedded embedded
+}
+
 foo.localhost {
 	root * /foo
 	file_server {


### PR DESCRIPTION
Resolves https://github.com/caddyserver/xcaddy/issues/203. I also added a little flavor text to draw attention to the filesystem line in the example.

I verified with a manual test that instantiating the filesystem with the same name as the `caddy.fs` module works fine.