### PR TITLE
docs: Expand + clarify `--embed` docs, esp. for usage without alias

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -51,7 +51,7 @@ Flags:
 
  --replace is like --with, but does not add a blank import to the code; it only writes a replace directive to go.mod, which is useful when developing on Caddy's dependencies (ones that are not Caddy modules). Try this if you got an error when using --with, like cannot find module providing package.
 
- --embed can be used multiple times to embed directories into the built Caddy executable. The directory can be prefixed with a custom alias and a colon : to use it with the root directive and sub-directive. Example: xcaddy build --embed foo:./sites/foo --embed bar:./sites/bar (This allows you to serve 2 sites from 2 different embedded directories, which are referenced by aliases, from a single Caddy executable).
+ --embed can be used to embed the contents of a directory into the Caddy executable. --embed can be passed multiple times with separate source directories. The source directory can be prefixed with a custom alias and a colon : to write the embedded files into an aliased subdirectory, which is useful when combined with the root directive and sub-directive.
 `,
 	Short: "Compile custom caddy binaries",
 	Args:  cobra.MaximumNArgs(1),


### PR DESCRIPTION
Another small docs PR for `--embed` flag usage 🎏 

My main goal here was to add documentation for the way `--embed` behaves _without_ an alias for the source directory, which writes the contents of the source directory into the root* of the embedded FS without any containing subdirectory. This behavior, while perfectly ergonomic for making a file server, had confused me briefly as a new user (see #202).

Since the `--embed` examples in the README have been expanded + annotated, I removed the inline example from the command usage text in the source code. I think using this space for text that documents the unaliased behavior is worth it, but I'm happy to re-add the inline example if preferred.

<sub>*_yes, technically into the `/files` intermediate dir, but this is the root from the user's perspective_</sub>