### PR TITLE
docs: Remove `sh` language hint from Caddyfile examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This allows you to hack on Caddy core (and optionally plug in extra modules at t
 
 If `--embed` is used without an alias prefix, the contents of the source directory are written directly into the root directory of the embedded filesystem within the Caddy executable. The contents of multiple unaliased source directories will be merged together:
 
-```sh
+```
 $ xcaddy build --embed ./my-files --embed ./my-other-files
 $ cat Caddyfile
 {
@@ -139,7 +139,7 @@ localhost {
 
 You may also prefix the source directory with a custom alias and colon separator to write the source directory's contents to a separate subdirectory within the `embedded` filesystem:
 
-```sh
+```
 $ xcaddy build --embed foo:./sites/foo --embed bar:./sites/bar
 $ cat Caddyfile
 {

--- a/README.md
+++ b/README.md
@@ -122,15 +122,15 @@ If `--embed` is used without an alias prefix, the contents of the source directo
 $ xcaddy build --embed ./my-files --embed ./my-other-files
 $ cat Caddyfile
 {
-    # You must declare a custom filesystem using the `embedded` module.
-    # The first argument to `filesystem` is an arbitrary identifier
-    # that will also be passed to `fs` directives.
-    filesystem my_embeds embedded
+	# You must declare a custom filesystem using the `embedded` module.
+	# The first argument to `filesystem` is an arbitrary identifier
+	# that will also be passed to `fs` directives.
+	filesystem my_embeds embedded
 }
 
 localhost {
-    # This serves the files or directories that were
-    # contained inside of ./my-files and ./my-other-files
+	# This serves the files or directories that were
+	# contained inside of ./my-files and ./my-other-files
 	file_server {
 		fs my_embeds
 	}
@@ -143,12 +143,12 @@ You may also prefix the source directory with a custom alias and colon separator
 $ xcaddy build --embed foo:./sites/foo --embed bar:./sites/bar
 $ cat Caddyfile
 {
-    filesystem my_embeds embedded
+	filesystem my_embeds embedded
 }
 
 foo.localhost {
-    # This serves the files or directories that were
-    # contained inside of ./sites/foo
+	# This serves the files or directories that were
+	# contained inside of ./sites/foo
 	root * /foo
 	file_server {
 		fs my_embeds
@@ -156,8 +156,8 @@ foo.localhost {
 }
 
 bar.localhost {
-    # This serves the files or directories that were
-    # contained inside of ./sites/bar
+	# This serves the files or directories that were
+	# contained inside of ./sites/bar
 	root * /bar
 	file_server {
 		fs my_embeds


### PR DESCRIPTION
Addressing https://github.com/caddyserver/xcaddy/pull/206#discussion_r1772249221

These sneaked in unintentionally, sorry! It doesn't make sense to type a mostly-Caddyfile block as `sh`.

Also fixed my usage of spaces for indentation in the Caddyfile blocks in favor of tabs.