### PR TITLE
Extract correct version when using --with flag to replace Caddy core

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -107,6 +107,10 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 
 		// output looks like: github.com/caddyserver/caddy/v2 v2.7.6
 		version := strings.TrimSpace(strings.TrimPrefix(buffer.String(), buildEnv.caddyModulePath))
+		index := strings.Index(version, "=>")
+		if index != -1 {
+			version = strings.TrimSpace(version[:index])
+		}
 		err = utils.WindowsResource(version, outputFile, buildEnv.tempFolder)
 		if err != nil {
 			return err


### PR DESCRIPTION
The following build failed on Windows with `Invalid Semantic Version` error.
`xcaddy build v2.8.4 --with github.com/caddyserver/caddy/v2=c:\Users\test\caddy`

The bug is among lines 97 - 110 in the builder.go.
```
	// generating windows resources for embedding
	if b.OS == "windows" {
		// get version string, we need to parse the output to get the exact version instead tag, branch or commit
		cmd := buildEnv.newGoBuildCommand(ctx, "list", "-m", buildEnv.caddyModulePath)
		var buffer bytes.Buffer
		cmd.Stdout = &buffer
		err = buildEnv.runCommand(ctx, cmd)
		if err != nil {
			return err
		}

		// output looks like: github.com/caddyserver/caddy/v2 v2.7.6
		version := strings.TrimSpace(strings.TrimPrefix(buffer.String(), buildEnv.caddyModulePath))

		err = utils.WindowsResource(version, outputFile, buildEnv.tempFolder)
```

Detailed explanation:
The `go list -m` command in this case would return `github.com/caddyserver/caddy/v2 v2.8.4 => c:\Users\test\caddy`. The value of the `version` would end up being `v2.8.4 => c:\Users\test\Documents\EyeSCADA-v4\_esRouter\caddy-2.8.4`. Therefore, the `utils.WIndows Resource()` call would fail with 'Invalid Semantic Version` error.

A quick fix would be adding the following between `version := ...` and `err = util.WIndowsResource(...)`:

```
index := strings.Index(version, "=>")
if index != -1 {
    version = strings.TrimSpace(version[:index])
}
```