### PR TITLE
bugfix- #221, xcaddy skips minor updates of lexical submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ cmd/xcaddy/caddy.exe
 
 # goreleaser artifacts
 dist/
+
+# jb
+.idea
+.fleet

--- a/environment.go
+++ b/environment.go
@@ -185,7 +185,7 @@ nextPlugin:
 		// a plugin package may be a subfolder of a module, i.e.
 		// foo/a/plugin is within module foo/a.
 		for repl := range replaced {
-			if strings.HasPrefix(p.PackagePath, repl) {
+			if strings.HasPrefix(p.PackagePath, repl+"/") {
 				continue nextPlugin
 			}
 		}

--- a/environment.go
+++ b/environment.go
@@ -180,31 +180,32 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 	}
 nextPlugin:
 	for _, p := range b.Plugins {
-		
-		// Still fetch new modules and check is the latest or tagged version is viable
+		// still fetch new modules and check is the latest or tagged version is viable
 		// regardless if this is in reference to a local module, lexical submodule or minor semantic revision.
 		//
 		// see issue caddyserver/xcaddy/issues/221 for more info about line
 		// with or without `if strings.HasPrefix(p.PackagePath, repl+"/") ... `
 		//
 		// In the case of lexical submodules:
-		// say you are requiring both submodules libdns<version> *and* libdns-provider<your new dns provider> 
-		// your new local dns provder module prefixed with `libdns-` will be skipped when running 
+		// say you are requiring both submodules libdns<version> *and* libdns-provider<your new dns provider>
+		// your new local dns provder module prefixed with `libdns-` will be skipped when running
 		// xcaddy `build --with libdns-provider<your new dns provider> ...`
 		//
 		// In the case of semantic and/or local submodules:
-		// say you are requiring both submodules <template> and <template>-caddy, 
+		// say you are requiring both submodules <template> and <template>-caddy,
 		// where you are working on your template module.
 		// xcaddy build --with FQDN/<template>-caddy@<Real Tag> --with FQDN/<template=.
 		//
-		// You should expect xcaddy to be able fetch newer submodule versions, ie FQDN/<template>-caddy@<Real Tag+1> 
-		// or properly fail if you specify a false minor semantic revision submodule FQDN/<template>-caddy@<False Tag+9> 
-		// while working from its parent module directory as a local override.  
+		// You should expect xcaddy to be able fetch newer submodule versions, i.e.
+		//   FQDN/<template>-caddy@<Real Tag+1>
+		// or properly fail if you specify a false minor semantic revision submodule,
+		//   FQDN/<template>-caddy@<False Tag+9>
+		// while working from its parent module directory as a local override.
 		//
 		// This is all to say, while we iterate and check prefixes,
 		// a plugin package may be a subfolder of a module, i.e.
-		// foo/a/plugin is within module foo/a 
-		// *or* a lexical submodule, and in either case tagged versions should be checked.  
+		// foo/a/plugin is within module foo/a
+		// *or* a lexical submodule, and in either case tagged versions should be checked.
 		for repl := range replaced {
 			if strings.HasPrefix(p.PackagePath, repl+"/") {
 				continue nextPlugin

--- a/environment.go
+++ b/environment.go
@@ -180,10 +180,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 	}
 nextPlugin:
 	for _, p := range b.Plugins {
-		// if module is locally available, do not "go get" it;
-		// also note that we iterate and check prefixes, because
-		// a plugin package may be a subfolder of a module, i.e.
-		// foo/a/plugin is within module foo/a.
+		// if module is locally available, still go get it 
 		for repl := range replaced {
 			if strings.HasPrefix(p.PackagePath, repl+"/") {
 				continue nextPlugin

--- a/environment.go
+++ b/environment.go
@@ -180,7 +180,31 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 	}
 nextPlugin:
 	for _, p := range b.Plugins {
-		// if module is locally available, still go get it 
+		
+		// Still fetch new modules and check is the latest or tagged version is viable
+		// regardless if this is in reference to a local module, lexical submodule or minor semantic revision.
+		//
+		// see issue caddyserver/xcaddy/issues/221 for more info about line
+		// with or without `if strings.HasPrefix(p.PackagePath, repl+"/") ... `
+		//
+		// In the case of lexical submodules:
+		// say you are requiring both submodules libdns<version> *and* libdns-provider<your new dns provider> 
+		// your new local dns provder module prefixed with `libdns-` will be skipped when running 
+		// xcaddy `build --with libdns-provider<your new dns provider> ...`
+		//
+		// In the case of semantic and/or local submodules:
+		// say you are requiring both submodules <template> and <template>-caddy, 
+		// where you are working on your template module.
+		// xcaddy build --with FQDN/<template>-caddy@<Real Tag> --with FQDN/<template=.
+		//
+		// You should expect xcaddy to be able fetch newer submodule versions, ie FQDN/<template>-caddy@<Real Tag+1> 
+		// or properly fail if you specify a false minor semantic revision submodule FQDN/<template>-caddy@<False Tag+9> 
+		// while working from its parent module directory as a local override.  
+		//
+		// This is all to say, while we iterate and check prefixes,
+		// a plugin package may be a subfolder of a module, i.e.
+		// foo/a/plugin is within module foo/a 
+		// *or* a lexical submodule, and in either case tagged versions should be checked.  
 		for repl := range replaced {
 			if strings.HasPrefix(p.PackagePath, repl+"/") {
 				continue nextPlugin


### PR DESCRIPTION
Resolves #221 

Current behavior:
- xcaddy skips minor updates of lexical submodules

Intended behavior:
- xcaddy will ingest logically tagged and / or latest modules when semantically updated or a new release is available to @latest.


### To demo the bug:


```shell
git clone https://github.com/infogulch/xtemplate && cd xtemplate
xcaddy build --with github.com/infogulch/xtemplate-caddy@v0.2.2 --with github.com/infogulch/xtemplate=.
go get github.com/infogulch/xtemplate-caddy@v0.2.2

# this should fail, but does not:
xcaddy build --with github.com/infogulch/xtemplate-caddy@v0.2.5 --with github.com/infogulch/xtemplate=.

# note, this behavior cannot be replicated with major semantic changes, eg, v0 --> v1.
```

### To demo the fix:

```shell
# get extant release
git clone https://github.com/jesssullivan/xcaddy && cd xcaddy
git checkout 221-fetch-uncached-modules
cd 221-xtemplate-caddy 
go mod tidy && go build -o xcaddy ./cmd/xcaddy

cd ../xtemplate
./xcaddy/xcaddy build --with github.com/infogulch/xtemplate-caddy@v0.2.5 --with github.com/infogulch/xtemplate=. # <-- successfully fails ^w^
```