### PR TITLE
Support setting version string via ldflags

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,6 +33,18 @@ import (
 	"github.com/caddyserver/xcaddy/internal/utils"
 )
 
+// CustomVersion is an optional string that overrides xcaddy's
+// reported version. It can be helpful when downstream packagers
+// need to manually set xcaddy's version, since building as the
+// main module causes debug.ReadBuildInfo() to report "(devel)".
+//
+// Set this variable during `go build` with `-ldflags`:
+//
+//	-ldflags '-X github.com/caddyserver/xcaddy/cmd.CustomVersion=v0.4.4'
+//
+// for example.
+var CustomVersion string
+
 var (
 	caddyVersion     = os.Getenv("CADDY_VERSION")
 	raceDetector     = os.Getenv("XCADDY_RACE_DETECTOR") == "1"
@@ -207,6 +219,9 @@ func splitWith(arg string) (module, version, replace string, err error) {
 
 // xcaddyVersion returns a detailed version string, if available.
 func xcaddyVersion() string {
+	if CustomVersion != "" {
+		return CustomVersion
+	}
 	mod := goModule()
 	ver := mod.Version
 	if mod.Sum != "" {


### PR DESCRIPTION
When xcaddy is built directly from source (e.g. distro packaging), Go's debug.ReadBuildInfo() reports the main module version as "(devel)" rather than the actual release version. The upstream build process works around this by building from a separate wrapper module that imports xcaddy as a versioned dependency, but packagers typically build directly from the source tarball.

Add a version variable that can be set via -ldflags -X at build time, allowing packagers to inject the correct version string.

---

Other Go projects also do similar:
- https://github.com/anchore/grype/blob/main/cmd/grype/main.go#L16
- https://github.com/anchore/syft/blob/main/cmd/syft/main.go#L16
- https://github.com/hashicorp/terraform/blob/main/version/version.go#L18-L38
- https://github.com/kubernetes/component-base/blob/master/version/base.go#L30-L57