### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/cmd/main_unix_test.go
+++ b/cmd/main_unix_test.go
@@ -85,7 +85,7 @@ func TestParseGoListJson(t *testing.T) {
 }
 `))
 	if err != nil {
-		t.Errorf("Error occured during JSON parsing")
+		t.Errorf("Error occurred during JSON parsing")
 	}
 	if currentModule != "github.com/simnalamburt/module" {
 		t.Errorf("Unexpected module name")

--- a/cmd/main_windows_test.go
+++ b/cmd/main_windows_test.go
@@ -89,7 +89,7 @@ func TestParseGoListJson(t *testing.T) {
 }
 `))
 	if err != nil {
-		t.Errorf("Error occured during JSON parsing")
+		t.Errorf("Error occurred during JSON parsing")
 	}
 	if currentModule != "github.com/simnalamburt/module" {
 		t.Errorf("Unexpected module name")


### PR DESCRIPTION
Fixes a spelling typo in the JSON parsing error messages in the unix and windows test files.