### PR TITLE
implement XCADDY_PRINT_VERSION env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Because the subcommands and flags are constrained to benefit rapid plugin protot
 - `XCADDY_WHICH_GO` sets the go command to use when for example more then 1 version of go is installed.
 - `XCADDY_GO_BUILD_FLAGS` overrides default build arguments. Supports Unix-style shell quoting, for example: XCADDY_GO_BUILD_FLAGS="-ldflags '-w -s'". The provided flags are applied to `go` commands: build, clean, get, install, list, run, and test
 - `XCADDY_GO_MOD_FLAGS` overrides default `go mod` arguments. Supports Unix-style shell quoting.
+- `XCADDY_PRINT_VERSION` prints the Caddy version after building to prove the build is working (defaults to 1).
 
 ---
 

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -180,8 +180,10 @@ Flags:
 			return err
 		}
 
+        var printVersion = os.Getenv("XCADDY_PRINT_VERSION") != "0"
+
 		// prove the build is working by printing the version
-		if runtime.GOOS == utils.GetGOOS() && runtime.GOARCH == utils.GetGOARCH() {
+        if printVersion && runtime.GOOS == utils.GetGOOS() && runtime.GOARCH == utils.GetGOARCH() {
 			if !filepath.IsAbs(output) {
 				output = "." + string(filepath.Separator) + output
 			}


### PR DESCRIPTION
Addresses #270.

I have thought of handling `GOAMD64`, though after reading [the docs](https://go.dev/wiki/MinimumRequirements#amd64)  I realized there’s much more to implement if we want to handle feature levels properly (`GOARM`, `GO386`…).

So this PR implements a simpler fix, the `XCADDY_PRINT_VERSION` variable. Defaults to 1. If set to `0`, `xcaddy` won’t attempt to execute `caddy version` after a `xcaddy build`. That’s all.

Disclaimer: I’m not a Go developer at all. Even some random AI code-spewing machine would likely implement something a little better… who knows.