### PR TITLE
Expose build steps and per-step output to API consumers

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -17,7 +17,9 @@ package xcaddy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path"
@@ -26,6 +28,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -54,11 +57,253 @@ type Builder struct {
 		Dir  string `json:"dir,omitempty"`
 		Name string `json:"name,omitempty"`
 	} `json:"embed_dir,omitempty"`
+
+	// OnStep, if set, is called for each build step, making the
+	// build's progress observable and controllable. The callback
+	// runs in its own goroutine, concurrently with the step it
+	// describes, so it can consume the event's Output directly,
+	// with no extra goroutine of its own:
+	//
+	//	OnStep: func(e *xcaddy.StepEvent) error {
+	//		scanner := bufio.NewScanner(e.Output)
+	//		for scanner.Scan() {
+	//			showProgress(e.Step, scanner.Text())
+	//		}
+	//		return scanner.Err()
+	//	}
+	//
+	// Callbacks never overlap: the next step does not begin until
+	// the previous step's callback has returned, and Build does
+	// not return until the final callback has returned. Output
+	// reaches EOF when the step ends, so a callback that reads
+	// until EOF returns naturally at the step boundary; one that
+	// lingers afterward delays the build accordingly.
+	//
+	// Returning a non-nil error aborts the build at the end of
+	// the step: no further steps begin, and the error is returned
+	// from Build, wrapped with the step name (use errors.Is or
+	// errors.As to match a custom error). To cancel mid-step,
+	// cancel the context passed to Build instead. Aborting does
+	// not skip removal of the temporary build folder. The
+	// callback must not call back into the Builder.
+	OnStep func(event *StepEvent) error `json:"-"`
+}
+
+// StepEvent describes a build step that is about to begin. It is
+// passed to a Builder's OnStep callback.
+type StepEvent struct {
+	// Step identifies the step that is beginning.
+	Step Step
+
+	// Output reads everything the step produces: xcaddy's own log
+	// lines (in their usual "[INFO] ..." format) as well as the
+	// stdout and stderr of the underlying go commands (go mod,
+	// go get, go build, ...). The Builder buffers this output
+	// internally, so the build never blocks on a slow reader
+	// mid-step; output is available to read the moment it is
+	// produced.
+	//
+	// When the step ends, the Builder closes the write side, so
+	// after any remaining buffered output is drained the reader
+	// reaches EOF; reading until EOF is the only lifecycle a
+	// consumer needs. Output that is never read is discarded when
+	// the step's buffer is released.
+	Output io.Reader
+}
+
+// Step identifies a phase of the build process. Steps are
+// reported to a Builder's OnStep callback, if set.
+type Step string
+
+// The build steps, in the order they occur. StepWindowsResources
+// only occurs when targeting Windows; StepTidyModule and
+// StepCompile do not occur if SkipBuild is enabled; and
+// StepCleanup does not occur if SkipCleanup is enabled.
+const (
+	StepCreateEnvironment Step = "create_environment" // set up the temporary build module
+	StepInitializeModule  Step = "initialize_module"  // go mod init and module replacements
+	StepPinVersions       Step = "pin_versions"       // go get Caddy and plugins
+	StepWindowsResources  Step = "windows_resources"  // generate Windows version resources
+	StepTidyModule        Step = "tidy_module"        // go mod tidy
+	StepCompile           Step = "compile"            // go build
+	StepCleanup           Step = "cleanup"            // remove the temporary folder
+)
+
+// buildOutput routes all output of a single build (xcaddy's own
+// log lines and the go commands' stdout/stderr) to the writer
+// designated for the current step by the OnStep callback.
+type buildOutput struct {
+	onStep func(*StepEvent) error
+	logger *log.Logger
+
+	mu   sync.Mutex
+	pipe *bufferedPipe // buffer for the current step; nil = defaults
+
+	// the currently-running step callback; accessed only from the
+	// build's own goroutine (in beginStep/endStep), never concurrently
+	handlerStep Step
+	handlerDone chan error
+}
+
+func newBuildOutput(onStep func(*StepEvent) error) *buildOutput {
+	out := &buildOutput{onStep: onStep}
+	if onStep == nil {
+		// historical behavior: the standard log package's default logger
+		out.logger = log.Default()
+	} else {
+		out.logger = log.New(out.stderr(), "", log.LstdFlags)
+	}
+	return out
+}
+
+// beginStep marks the start of a build step: it first ends the
+// previous step, if any -- waiting for its callback to return --
+// and then starts the OnStep callback for the new step in its own
+// goroutine, handing it a reader over the step's output. A
+// non-nil error means the previous step's callback aborted the
+// build, and the new step must not run.
+func (o *buildOutput) beginStep(step Step) error {
+	if o.onStep == nil {
+		return nil
+	}
+	if err := o.endStep(); err != nil {
+		return err
+	}
+	pipe := newBufferedPipe()
+	event := &StepEvent{Step: step, Output: pipe}
+	done := make(chan error, 1)
+	go func() {
+		done <- o.onStep(event)
+	}()
+	o.mu.Lock()
+	o.pipe = pipe
+	o.mu.Unlock()
+	o.handlerStep = step
+	o.handlerDone = done
+	return nil
+}
+
+// endStep ends the current step, if any: it closes the write side
+// of the step's buffered pipe -- once the remaining buffered
+// output is drained, the callback's reader reaches EOF, signaling
+// that the step's output is complete -- and then waits for the
+// step's callback to return. By the time endStep is called, all
+// of the step's commands have finished, so all output has been
+// produced and EOF is guaranteed to arrive; a callback that reads
+// until EOF can therefore never deadlock the build. A non-nil
+// error from the callback aborts the build.
+func (o *buildOutput) endStep() error {
+	o.mu.Lock()
+	pipe := o.pipe
+	o.pipe = nil
+	o.mu.Unlock()
+	if pipe == nil {
+		return nil
+	}
+	pipe.Close()
+	err := <-o.handlerDone
+	o.handlerDone = nil
+	if err != nil {
+		return fmt.Errorf("step %s: %w", o.handlerStep, err)
+	}
+	return nil
+}
+
+// stdout and stderr return writers to wire subprocess output to;
+// they write to the current step's writer, or fall back to the
+// conventional os stream if none is designated.
+func (o *buildOutput) stdout() io.Writer { return outputFacet{o, os.Stdout} }
+func (o *buildOutput) stderr() io.Writer { return outputFacet{o, os.Stderr} }
+
+type outputFacet struct {
+	out      *buildOutput
+	fallback io.Writer
+}
+
+// Write routes p to the current step's buffered pipe, falling
+// back to the facet's default stream if no step is active.
+func (f outputFacet) Write(p []byte) (int, error) {
+	f.out.mu.Lock()
+	pipe := f.out.pipe
+	f.out.mu.Unlock()
+	if pipe == nil {
+		return f.fallback.Write(p)
+	}
+	return pipe.Write(p)
+}
+
+// bufferedPipe is an in-memory pipe with a write side that never
+// blocks: writes append to an internal buffer, and reads block
+// until data is available or the write side has been closed, at
+// which point draining the remaining buffer ends in io.EOF.
+// It is safe for concurrent use; os/exec drains a command's
+// stdout and stderr on separate goroutines, and the serialization
+// here means step output is delivered to the consumer's reader
+// atomically per write.
+type bufferedPipe struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	buf    bytes.Buffer
+	closed bool
+}
+
+func newBufferedPipe() *bufferedPipe {
+	p := new(bufferedPipe)
+	p.cond = sync.NewCond(&p.mu)
+	return p
+}
+
+func (p *bufferedPipe) Write(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		// the step already ended; discard rather than error so a
+		// stray late write can never fail the build
+		return len(b), nil
+	}
+	n, err := p.buf.Write(b)
+	p.cond.Broadcast()
+	return n, err
+}
+
+func (p *bufferedPipe) Read(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for p.buf.Len() == 0 && !p.closed {
+		p.cond.Wait()
+	}
+	if p.buf.Len() == 0 {
+		return 0, io.EOF
+	}
+	return p.buf.Read(b)
+}
+
+// Close closes the write side of the pipe: subsequent writes are
+// discarded, and readers reach EOF once the buffer is drained.
+func (p *bufferedPipe) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	p.cond.Broadcast()
+	return nil
 }
 
 // Build builds Caddy at the configured version with the
 // configured plugins and plops down a binary at outputFile.
-func (b Builder) Build(ctx context.Context, outputFile string) error {
+func (b Builder) Build(ctx context.Context, outputFile string) (err error) {
+	out := newBuildOutput(b.OnStep)
+	// registered before buildEnv.Close (deferred below), so it runs
+	// after it: it ends the final step -- normally cleanup --
+	// delivering its EOF and waiting for its callback to return, so
+	// that no callback goroutine outlives Build
+	defer func() {
+		err = errors.Join(err, out.endStep())
+	}()
+	if err := out.beginStep(StepCreateEnvironment); err != nil {
+		return err
+	}
+	logger := out.logger
+
 	var cancel context.CancelFunc
 	if b.TimeoutBuild > 0 {
 		ctx, cancel = context.WithTimeout(ctx, b.TimeoutBuild)
@@ -75,7 +320,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("[INFO] absolute output file path: %s", absOutputFile)
+	logger.Printf("[INFO] absolute output file path: %s", absOutputFile)
 
 	// likewise with the PGO profile
 	absPgoProfile, err := filepath.Abs(b.PgoProfile)
@@ -95,14 +340,20 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	}
 
 	// prepare the build environment
-	buildEnv, err := b.newEnvironment(ctx)
+	buildEnv, err := b.newEnvironment(ctx, out)
 	if err != nil {
 		return err
 	}
-	defer buildEnv.Close()
+	defer func() {
+		err = errors.Join(err, buildEnv.Close())
+	}()
 
 	// generating windows resources for embedding
 	if b.OS == "windows" {
+		if err := out.beginStep(StepWindowsResources); err != nil {
+			return err
+		}
+
 		// get version string, we need to parse the output to get the exact version instead tag, branch or commit
 		cmd, err := buildEnv.newGoBuildCommand(ctx, "list", "-m", buildEnv.caddyModulePath)
 		if err != nil {
@@ -130,7 +381,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	}
 
 	if b.SkipBuild {
-		log.Printf("[INFO] Skipping build as requested")
+		logger.Printf("[INFO] Skipping build as requested")
 
 		return nil
 	}
@@ -143,25 +394,31 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	env = setEnv(env, "GOARCH="+b.Arch)
 	env = setEnv(env, "GOARM="+b.ARM)
 	if b.RaceDetector && !b.Compile.Cgo {
-		log.Println("[WARNING] Enabling cgo because it is required by the race detector")
+		logger.Println("[WARNING] Enabling cgo because it is required by the race detector")
 		b.Compile.Cgo = true
 	}
 	env = setEnv(env, fmt.Sprintf("CGO_ENABLED=%s", b.Compile.CgoEnabled()))
 
-	log.Println("[INFO] Building Caddy")
+	logger.Println("[INFO] Building Caddy")
 
 	// tidy the module to ensure go.mod and go.sum are consistent with the module prereq
+	if err := out.beginStep(StepTidyModule); err != nil {
+		return err
+	}
 	tidyCmd := buildEnv.newGoModCommand(ctx, "tidy", "-e")
 	if err := buildEnv.runCommand(ctx, tidyCmd); err != nil {
 		return err
 	}
 
 	// compile
+	if err := out.beginStep(StepCompile); err != nil {
+		return err
+	}
 	cmd, err := buildEnv.newGoBuildCommand(ctx, "build",
 		"-o", absOutputFile,
 	)
 	if b.PgoProfile != "" {
-		log.Printf("[INFO] using PGO profile %s", b.PgoProfile)
+		logger.Printf("[INFO] using PGO profile %s", b.PgoProfile)
 		cmd.Args = append(cmd.Args, "-pgo="+absPgoProfile)
 	}
 	if err != nil {
@@ -189,7 +446,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 		return err
 	}
 
-	log.Printf("[INFO] Build complete: %s", outputFile)
+	logger.Printf("[INFO] Build complete: %s", outputFile)
 
 	return nil
 }

--- a/builder.go
+++ b/builder.go
@@ -87,6 +87,38 @@ type Builder struct {
 	// not skip removal of the temporary build folder. The
 	// callback must not call back into the Builder.
 	OnStep func(event *StepEvent) error `json:"-"`
+
+	// Env, if non-nil, is used as the entire environment of the
+	// underlying go commands, in KEY=value form (see os.Environ);
+	// the process's own environment is not inherited. This
+	// enables hermetic, credential-free builds: if build logs are
+	// published (see OnStep), no ambient credential (GOPROXY
+	// userinfo, git configuration, .netrc, cloud keys, ...) can
+	// leak into them when the build never had access to any. The
+	// environment must include everything the go toolchain needs,
+	// at minimum PATH and HOME (or GOCACHE and GOMODCACHE); GOOS,
+	// GOARCH, GOARM and CGO_ENABLED are set by the Builder
+	// itself. If nil, the process environment is inherited, which
+	// is the historical behavior.
+	Env []string `json:"-"`
+
+	// Secrets lists sensitive values (tokens, passwords, keys)
+	// that must not appear in step output: every occurrence is
+	// replaced with "[REDACTED]" before it reaches a StepEvent's
+	// Output. Matching is exact and line-buffered, so a secret
+	// cannot slip through by straddling a write boundary; values
+	// containing newlines cannot be matched. Secrets has no
+	// effect when OnStep is nil.
+	Secrets []string `json:"-"`
+
+	// RedactCredentials additionally masks common credential
+	// shapes in step output: userinfo in URLs, well-known token
+	// formats (GitHub, GitLab, Slack, AWS access key IDs), and
+	// PEM-encoded private key blocks. It is a best-effort
+	// backstop for publishable logs, not a guarantee; prefer
+	// building in a credential-free environment (see Env). It has
+	// no effect when OnStep is nil.
+	RedactCredentials bool `json:"-"`
 }
 
 // StepEvent describes a build step that is about to begin. It is
@@ -136,13 +168,32 @@ type buildOutput struct {
 	onStep func(*StepEvent) error
 	logger *log.Logger
 
+	// redaction configuration applied to each step's output
+	rules         []redactRule
+	maskKeyBlocks bool
+
 	mu   sync.Mutex
-	pipe *bufferedPipe // buffer for the current step; nil = defaults
+	sink io.WriteCloser // write side for the current step; nil = defaults
 
 	// the currently-running step callback; accessed only from the
 	// build's own goroutine (in beginStep/endStep), never concurrently
 	handlerStep Step
 	handlerDone chan error
+}
+
+// configureRedaction compiles the Builder's redaction settings
+// into rules applied to every step's output.
+func (o *buildOutput) configureRedaction(secrets []string, redactCredentials bool) {
+	for _, s := range secrets {
+		if s == "" {
+			continue
+		}
+		o.rules = append(o.rules, redactRule{literal: []byte(s)})
+	}
+	if redactCredentials {
+		o.rules = append(o.rules, builtinCredentialRules...)
+		o.maskKeyBlocks = true
+	}
 }
 
 func newBuildOutput(onStep func(*StepEvent) error) *buildOutput {
@@ -170,13 +221,17 @@ func (o *buildOutput) beginStep(step Step) error {
 		return err
 	}
 	pipe := newBufferedPipe()
+	var sink io.WriteCloser = pipe
+	if len(o.rules) > 0 || o.maskKeyBlocks {
+		sink = &redactor{dst: pipe, rules: o.rules, maskKeyBlocks: o.maskKeyBlocks}
+	}
 	event := &StepEvent{Step: step, Output: pipe}
 	done := make(chan error, 1)
 	go func() {
 		done <- o.onStep(event)
 	}()
 	o.mu.Lock()
-	o.pipe = pipe
+	o.sink = sink
 	o.mu.Unlock()
 	o.handlerStep = step
 	o.handlerDone = done
@@ -194,13 +249,13 @@ func (o *buildOutput) beginStep(step Step) error {
 // error from the callback aborts the build.
 func (o *buildOutput) endStep() error {
 	o.mu.Lock()
-	pipe := o.pipe
-	o.pipe = nil
+	sink := o.sink
+	o.sink = nil
 	o.mu.Unlock()
-	if pipe == nil {
+	if sink == nil {
 		return nil
 	}
-	pipe.Close()
+	sink.Close()
 	err := <-o.handlerDone
 	o.handlerDone = nil
 	if err != nil {
@@ -220,16 +275,17 @@ type outputFacet struct {
 	fallback io.Writer
 }
 
-// Write routes p to the current step's buffered pipe, falling
-// back to the facet's default stream if no step is active.
+// Write routes p to the current step's sink (the buffered pipe,
+// possibly behind a redactor), falling back to the facet's default
+// stream if no step is active.
 func (f outputFacet) Write(p []byte) (int, error) {
 	f.out.mu.Lock()
-	pipe := f.out.pipe
+	sink := f.out.sink
 	f.out.mu.Unlock()
-	if pipe == nil {
+	if sink == nil {
 		return f.fallback.Write(p)
 	}
-	return pipe.Write(p)
+	return sink.Write(p)
 }
 
 // bufferedPipe is an in-memory pipe with a write side that never
@@ -292,6 +348,7 @@ func (p *bufferedPipe) Close() error {
 // configured plugins and plops down a binary at outputFile.
 func (b Builder) Build(ctx context.Context, outputFile string) (err error) {
 	out := newBuildOutput(b.OnStep)
+	out.configureRedaction(b.Secrets, b.RedactCredentials)
 	// registered before buildEnv.Close (deferred below), so it runs
 	// after it: it ends the final step -- normally cleanup --
 	// delivering its EOF and waiting for its callback to return, so
@@ -386,10 +443,16 @@ func (b Builder) Build(ctx context.Context, outputFile string) (err error) {
 		return nil
 	}
 
-	// prepare the environment for the go command; for
-	// the most part we want it to inherit our current
-	// environment, with a few customizations
-	env := os.Environ()
+	// prepare the environment for the go command: either the
+	// caller's hermetic environment, or (for the most part) an
+	// inheritance of our current environment, with a few
+	// customizations
+	env := b.Env
+	if env == nil {
+		env = os.Environ()
+	} else {
+		env = append([]string(nil), env...) // don't mutate the caller's slice
+	}
 	env = setEnv(env, "GOOS="+b.OS)
 	env = setEnv(env, "GOARCH="+b.Arch)
 	env = setEnv(env, "GOARM="+b.ARM)

--- a/builder_test.go
+++ b/builder_test.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -465,5 +467,158 @@ func TestBuildOutputCallbacksNeverOverlap(t *testing.T) {
 	// endStep must have joined the final callback
 	if got := finished.Load(); got != int32(len(steps)) {
 		t.Errorf("after endStep: %d callbacks finished, want %d", got, len(steps))
+	}
+}
+
+func TestBuildOutputRedaction(t *testing.T) {
+	outputs := make(map[Step]string)
+	out := newBuildOutput(func(e *StepEvent) error {
+		data, err := io.ReadAll(e.Output)
+		if err != nil {
+			return err
+		}
+		outputs[e.Step] = string(data)
+		return nil
+	})
+	out.configureRedaction([]string{"hunter2secret"}, true)
+
+	if err := out.beginStep(StepPinVersions); err != nil {
+		t.Fatalf("beginStep() error = %v", err)
+	}
+	// an exact secret straddling two writes must still be caught
+	fmt.Fprint(out.stderr(), "token=hunter2se")
+	fmt.Fprint(out.stderr(), "cret done\n")
+	// built-in credential shapes
+	fmt.Fprint(out.stderr(), "fetch https://alice:s3cr3t@proxy.example.com/mod\n")
+	fmt.Fprint(out.stderr(), "oauth ghp_0123456789abcdefghijklmnop rejected\n")
+	fmt.Fprint(out.stderr(), "key AKIAIOSFODNN7EXAMPLE in env\n")
+	fmt.Fprint(out.stderr(), "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\n-----END RSA PRIVATE KEY-----\n")
+	// unterminated final line must be flushed (masked) at step end
+	fmt.Fprint(out.stderr(), "trailing hunter2secret partial")
+	if err := out.endStep(); err != nil {
+		t.Fatalf("endStep() error = %v", err)
+	}
+
+	got := outputs[StepPinVersions]
+	for _, leaked := range []string{
+		"hunter2secret", "s3cr3t", "alice",
+		"ghp_0123456789abcdefghijklmnop",
+		"AKIAIOSFODNN7EXAMPLE",
+		"MIIEowIBAAKCAQEA", "BEGIN RSA PRIVATE KEY",
+	} {
+		if strings.Contains(got, leaked) {
+			t.Errorf("output leaks %q:\n%s", leaked, got)
+		}
+	}
+	for _, want := range []string{
+		"token=[REDACTED] done",
+		"fetch https://[REDACTED]@proxy.example.com/mod",
+		"oauth [REDACTED] rejected",
+		"key [REDACTED] in env",
+		"trailing [REDACTED] partial",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestEnvironmentHermeticEnv(t *testing.T) {
+	// when Env is set, commands receive exactly that environment
+	hermetic := []string{"PATH=/usr/bin", "HOME=/tmp/home"}
+	env := environment{env: hermetic, out: newBuildOutput(nil)}
+	cmd := env.newCommand(context.Background(), "go", "version")
+	if !reflect.DeepEqual(cmd.Env, hermetic) {
+		t.Errorf("cmd.Env = %v, want %v", cmd.Env, hermetic)
+	}
+
+	// when Env is nil, commands inherit the process environment
+	// (exec's behavior for a nil cmd.Env)
+	env = environment{out: newBuildOutput(nil)}
+	cmd = env.newCommand(context.Background(), "go", "version")
+	if cmd.Env != nil {
+		t.Errorf("cmd.Env = %v, want nil (inherit)", cmd.Env)
+	}
+}
+
+// TestBuildHermeticEnv runs a real partial build with a minimal,
+// credential-free environment and verifies the go toolchain still
+// works within it. It aborts after initialize_module, so only local
+// go commands execute and no network access occurs.
+func TestBuildHermeticEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("a minimal hermetic environment needs platform-specific variables on Windows")
+	}
+	sentinel := errors.New("far enough")
+	outputs := make(map[Step]string)
+
+	b := Builder{
+		Compile:   Compile{Platform: Platform{OS: "linux", Arch: "amd64"}},
+		SkipBuild: true,
+		Env: []string{
+			"PATH=" + os.Getenv("PATH"),
+			"HOME=" + t.TempDir(), // fresh HOME: no .netrc, no .gitconfig, no caches
+		},
+		OnStep: func(e *StepEvent) error {
+			data, err := io.ReadAll(e.Output)
+			if err != nil {
+				return err
+			}
+			outputs[e.Step] = string(data)
+			if e.Step == StepInitializeModule {
+				return sentinel
+			}
+			return nil
+		},
+	}
+
+	err := b.Build(context.Background(), filepath.Join(t.TempDir(), "caddy"))
+	// reaching the sentinel proves `go mod init` succeeded inside
+	// the hermetic environment
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Build() error = %v, want errors.Is(err, sentinel)", err)
+	}
+	if got := outputs[StepInitializeModule]; !strings.Contains(got, "Initializing Go module") {
+		t.Errorf("initialize_module output missing init line:\n%s", got)
+	}
+}
+
+// TestBuildRedactsSecrets verifies end to end that a configured
+// secret never reaches step output, even when it appears in values
+// xcaddy logs itself (here: the output file path).
+func TestBuildRedactsSecrets(t *testing.T) {
+	sentinel := errors.New("far enough")
+	secret := "hunter2secret"
+	var all strings.Builder
+
+	b := Builder{
+		Compile:   Compile{Platform: Platform{OS: "linux", Arch: "amd64"}},
+		SkipBuild: true,
+		Secrets:   []string{secret},
+		OnStep: func(e *StepEvent) error {
+			data, err := io.ReadAll(e.Output)
+			if err != nil {
+				return err
+			}
+			all.Write(data)
+			if e.Step == StepInitializeModule {
+				return sentinel
+			}
+			return nil
+		},
+	}
+
+	outputFile := filepath.Join(t.TempDir(), secret, "caddy")
+	err := b.Build(context.Background(), outputFile)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Build() error = %v, want errors.Is(err, sentinel)", err)
+	}
+
+	got := all.String()
+	if strings.Contains(got, secret) {
+		t.Errorf("step output leaks the secret:\n%s", got)
+	}
+	if !strings.Contains(got, redactedPlaceholder) {
+		t.Errorf("step output contains no redaction placeholder; secret was never encountered?\n%s", got)
 	}
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -15,9 +15,20 @@
 package xcaddy
 
 import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
+	"io"
+	"log"
+	"path/filepath"
 	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestReplacementPath_Param(t *testing.T) {
@@ -84,5 +95,375 @@ func TestNewReplace(t *testing.T) {
 				t.Errorf("NewReplace() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildOutputPerStepContainment(t *testing.T) {
+	// the callback runs concurrently with the step and reads its
+	// output directly; no consumer-side goroutine is involved
+	var order []Step
+	outputs := make(map[Step]string)
+	out := newBuildOutput(func(e *StepEvent) error {
+		order = append(order, e.Step)
+		data, err := io.ReadAll(e.Output) // returns only at EOF, i.e. when the step ends
+		if err != nil {
+			return err
+		}
+		outputs[e.Step] = string(data)
+		return nil
+	})
+
+	if err := out.beginStep(StepCreateEnvironment); err != nil {
+		t.Fatalf("beginStep() error = %v", err)
+	}
+	out.logger.Print("[INFO] marker-log-environment")
+	fmt.Fprint(out.stdout(), "marker-stdout-environment")
+	fmt.Fprint(out.stderr(), "marker-stderr-environment")
+
+	if err := out.beginStep(StepCompile); err != nil {
+		t.Fatalf("beginStep() error = %v", err)
+	}
+	out.logger.Print("[INFO] marker-log-compile")
+	fmt.Fprint(out.stderr(), "marker-stderr-compile")
+
+	// ending the final step (as Build does when it returns) joins
+	// the last callback, after which all results are visible
+	if err := out.endStep(); err != nil {
+		t.Fatalf("endStep() error = %v", err)
+	}
+
+	wantOrder := []Step{StepCreateEnvironment, StepCompile}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Errorf("step order = %v, want %v", order, wantOrder)
+	}
+
+	envOut := outputs[StepCreateEnvironment]
+	for _, want := range []string{
+		"marker-log-environment",
+		"marker-stdout-environment",
+		"marker-stderr-environment",
+	} {
+		if !strings.Contains(envOut, want) {
+			t.Errorf("create_environment output missing %q; got:\n%s", want, envOut)
+		}
+	}
+	if strings.Contains(envOut, "compile") {
+		t.Errorf("create_environment output contains later step's output:\n%s", envOut)
+	}
+
+	compileOut := outputs[StepCompile]
+	for _, want := range []string{"marker-log-compile", "marker-stderr-compile"} {
+		if !strings.Contains(compileOut, want) {
+			t.Errorf("compile output missing %q; got:\n%s", want, compileOut)
+		}
+	}
+	if strings.Contains(compileOut, "environment") {
+		t.Errorf("compile output contains earlier step's output:\n%s", compileOut)
+	}
+}
+
+func TestBuildOutputNilCallback(t *testing.T) {
+	out := newBuildOutput(nil)
+
+	if out.logger != log.Default() {
+		t.Error("nil OnStep should use the standard log package's default logger")
+	}
+
+	// must be a no-op, not a panic
+	if err := out.beginStep(StepCompile); err != nil {
+		t.Fatalf("beginStep() error = %v", err)
+	}
+
+	// with no step active, facets write to their fallback stream
+	var fallback bytes.Buffer
+	facet := outputFacet{out, &fallback}
+	fmt.Fprint(facet, "marker-default")
+	if got := fallback.String(); got != "marker-default" {
+		t.Errorf("fallback got %q, want %q", got, "marker-default")
+	}
+}
+
+func TestBuildOutputUnreadIsDiscarded(t *testing.T) {
+	// a callback that returns without reading Output must not
+	// block or fail the build: writes are buffered and the buffer
+	// is released when the step ends; this test completing at all
+	// is the assertion
+	out := newBuildOutput(func(e *StepEvent) error { return nil })
+
+	for _, step := range []Step{StepCreateEnvironment, StepPinVersions, StepCompile} {
+		if err := out.beginStep(step); err != nil {
+			t.Fatalf("beginStep() error = %v", err)
+		}
+		for i := 0; i < 1000; i++ {
+			fmt.Fprintf(out.stderr(), "unread output %d\n", i)
+		}
+	}
+	if err := out.endStep(); err != nil {
+		t.Fatalf("endStep() error = %v", err)
+	}
+}
+
+func TestBuildOutputConcurrentWrites(t *testing.T) {
+	// during a step, os/exec drains a command's stdout and stderr
+	// on two separate goroutines, so both facets are written
+	// concurrently while the callback concurrently reads the
+	// step's pipe; this test mirrors that and exists primarily
+	// for the race detector
+	var total atomic.Int64
+	out := newBuildOutput(func(e *StepEvent) error {
+		n, err := io.Copy(io.Discard, e.Output)
+		total.Add(n)
+		return err
+	})
+
+	for _, step := range []Step{StepCreateEnvironment, StepCompile} {
+		if err := out.beginStep(step); err != nil {
+			t.Fatalf("beginStep(%s) error = %v", step, err)
+		}
+		var writers sync.WaitGroup
+		for _, w := range []io.Writer{out.stdout(), out.stderr()} {
+			writers.Add(1)
+			go func(w io.Writer) {
+				defer writers.Done()
+				for j := 0; j < 500; j++ {
+					fmt.Fprint(w, "xy")
+				}
+			}(w)
+		}
+		// as in a real build, all of the step's writes complete
+		// before the step ends
+		writers.Wait()
+	}
+	if err := out.endStep(); err != nil {
+		t.Fatalf("endStep() error = %v", err)
+	}
+
+	if want := int64(2 * 2 * 500 * 2); total.Load() != want {
+		t.Errorf("callbacks read %d bytes, want %d", total.Load(), want)
+	}
+}
+
+func TestBuildOutputAbort(t *testing.T) {
+	// a callback error aborts the build at the end of its step:
+	// the next step must not begin (its callback is never called)
+	sentinel := errors.New("stop right there")
+	var order []Step
+	out := newBuildOutput(func(e *StepEvent) error {
+		order = append(order, e.Step)
+		if _, err := io.ReadAll(e.Output); err != nil {
+			return err
+		}
+		if e.Step == StepInitializeModule {
+			return sentinel
+		}
+		return nil
+	})
+
+	if err := out.beginStep(StepCreateEnvironment); err != nil {
+		t.Fatalf("beginStep() error = %v", err)
+	}
+	if err := out.beginStep(StepInitializeModule); err != nil {
+		t.Fatalf("beginStep() error = %v", err)
+	}
+	fmt.Fprint(out.stderr(), "init-module output")
+
+	// joining initialize_module's callback surfaces the abort;
+	// pin_versions must never begin
+	err := out.beginStep(StepPinVersions)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("beginStep() error = %v, want errors.Is(err, sentinel)", err)
+	}
+	if !strings.Contains(fmt.Sprint(err), string(StepInitializeModule)) {
+		t.Errorf("error %q does not name the aborting step", err)
+	}
+
+	wantOrder := []Step{StepCreateEnvironment, StepInitializeModule}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Errorf("step order = %v, want %v", order, wantOrder)
+	}
+}
+
+// TestBuildStepOutput runs a real (network-dependent) partial build
+// and verifies that steps are reported in order and that each step's
+// output is readable from its event. It is skipped in -short mode.
+func TestBuildStepOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping network-dependent integration test in -short mode")
+	}
+
+	var order []Step
+	outputs := make(map[Step]string)
+
+	b := Builder{
+		Compile:   Compile{Platform: Platform{OS: "linux", Arch: "amd64"}},
+		SkipBuild: true, // exercise environment setup + go get, but skip the slow compile
+		OnStep: func(e *StepEvent) error {
+			order = append(order, e.Step)
+			data, err := io.ReadAll(e.Output)
+			if err != nil {
+				return err
+			}
+			outputs[e.Step] = string(data)
+			return nil
+		},
+	}
+
+	// Build joins the final callback before returning, so order and
+	// outputs are safe to read immediately afterwards
+	err := b.Build(context.Background(), filepath.Join(t.TempDir(), "caddy"))
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	wantOrder := []Step{StepCreateEnvironment, StepInitializeModule, StepPinVersions, StepCleanup}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Fatalf("step order = %v, want %v", order, wantOrder)
+	}
+
+	wantContained := map[Step]string{
+		StepCreateEnvironment: "[INFO] Temporary folder:",
+		StepInitializeModule:  "[INFO] Initializing Go module",
+		StepPinVersions:       "[INFO] Pinning versions",
+		StepCleanup:           "[INFO] Cleaning up temporary folder:",
+	}
+	for step, want := range wantContained {
+		if got := outputs[step]; !strings.Contains(got, want) {
+			t.Errorf("step %s output missing %q; got:\n%s", step, want, got)
+		}
+	}
+}
+
+// TestBuildAbort verifies that a callback error aborts a real Build
+// with the caller's error at the end of the callback's step. It
+// aborts at initialize_module, so only local go commands (go mod
+// init) execute and no network access occurs.
+func TestBuildAbort(t *testing.T) {
+	sentinel := errors.New("user says no")
+	var order []Step
+
+	b := Builder{
+		Compile:   Compile{Platform: Platform{OS: "linux", Arch: "amd64"}},
+		SkipBuild: true,
+		OnStep: func(e *StepEvent) error {
+			order = append(order, e.Step)
+			if e.Step == StepInitializeModule {
+				return sentinel
+			}
+			return nil
+		},
+	}
+
+	err := b.Build(context.Background(), filepath.Join(t.TempDir(), "caddy"))
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Build() error = %v, want errors.Is(err, sentinel)", err)
+	}
+
+	// pin_versions (the network step) must never have begun
+	wantOrder := []Step{StepCreateEnvironment, StepInitializeModule}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Errorf("step order = %v, want %v", order, wantOrder)
+	}
+}
+
+// TestBuildStreamsLinesLive exercises the live-progress consumer
+// pattern against a real Build invocation: the callback scans its
+// step's output line by line while the step runs, terminating at
+// the EOF delivered when the step ends. It aborts after
+// initialize_module, so only local go commands execute and no
+// network access occurs.
+func TestBuildStreamsLinesLive(t *testing.T) {
+	sentinel := errors.New("stop before network")
+
+	type line struct {
+		step Step
+		text string
+	}
+	var lines []line
+
+	b := Builder{
+		Compile:   Compile{Platform: Platform{OS: "linux", Arch: "amd64"}},
+		SkipBuild: true,
+		OnStep: func(e *StepEvent) error {
+			scanner := bufio.NewScanner(e.Output)
+			for scanner.Scan() { // consume live, line by line
+				lines = append(lines, line{e.Step, scanner.Text()})
+			}
+			if err := scanner.Err(); err != nil {
+				return err
+			}
+			if e.Step == StepInitializeModule {
+				return sentinel
+			}
+			return nil
+		},
+	}
+
+	err := b.Build(context.Background(), filepath.Join(t.TempDir(), "caddy"))
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Build() error = %v, want errors.Is(err, sentinel)", err)
+	}
+
+	byStep := make(map[Step][]string)
+	for _, l := range lines {
+		byStep[l.step] = append(byStep[l.step], l.text)
+	}
+
+	wantContained := map[Step]string{
+		StepCreateEnvironment: "[INFO] Temporary folder:",
+		StepInitializeModule:  "[INFO] Initializing Go module",
+	}
+	for step, want := range wantContained {
+		found := false
+		for _, l := range byStep[step] {
+			if strings.Contains(l, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("step %s: no scanned line contains %q; got %d lines:\n%s",
+				step, want, len(byStep[step]), strings.Join(byStep[step], "\n"))
+		}
+	}
+}
+
+func TestBuildOutputCallbacksNeverOverlap(t *testing.T) {
+	// documented guarantees: callbacks never overlap, and the next
+	// step does not begin until the previous step's callback has
+	// returned -- even if the callback lingers after reading EOF
+	var active, finished atomic.Int32
+
+	out := newBuildOutput(func(e *StepEvent) error {
+		if n := active.Add(1); n != 1 {
+			t.Errorf("step %s: %d callbacks active, want 1", e.Step, n)
+		}
+		defer active.Add(-1)
+
+		if _, err := io.ReadAll(e.Output); err != nil {
+			return err
+		}
+		time.Sleep(10 * time.Millisecond) // linger past EOF
+		finished.Add(1)
+		return nil
+	})
+
+	steps := []Step{StepCreateEnvironment, StepInitializeModule, StepPinVersions, StepCompile}
+	for i, step := range steps {
+		if err := out.beginStep(step); err != nil {
+			t.Fatalf("beginStep(%s) error = %v", step, err)
+		}
+		// beginStep must have joined all previous callbacks
+		if got := finished.Load(); got != int32(i) {
+			t.Errorf("after beginStep(%s): %d callbacks finished, want %d", step, got, i)
+		}
+		fmt.Fprintf(out.stderr(), "output of %s", step)
+	}
+
+	if err := out.endStep(); err != nil {
+		t.Fatalf("endStep() error = %v", err)
+	}
+	// endStep must have joined the final callback
+	if got := finished.Load(); got != int32(len(steps)) {
+		t.Errorf("after endStep: %d callbacks finished, want %d", got, len(steps))
 	}
 }

--- a/environment.go
+++ b/environment.go
@@ -17,6 +17,7 @@ package xcaddy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -30,7 +31,9 @@ import (
 	"github.com/google/shlex"
 )
 
-func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
+func (b Builder) newEnvironment(ctx context.Context, out *buildOutput) (*environment, error) {
+	logger := out.logger
+
 	// assume Caddy v2 if no semantic version is provided
 	caddyModulePath := defaultCaddyModulePath
 	if !strings.HasPrefix(b.CaddyVersion, "v") || !strings.Contains(b.CaddyVersion, ".") {
@@ -84,11 +87,11 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 			}
 		}
 	}()
-	log.Printf("[INFO] Temporary folder: %s", tempFolder)
+	logger.Printf("[INFO] Temporary folder: %s", tempFolder)
 
 	// write the main module file to temporary folder
 	mainPath := filepath.Join(tempFolder, "main.go")
-	log.Printf("[INFO] Writing main module: %s\n%s", mainPath, buf.Bytes())
+	logger.Printf("[INFO] Writing main module: %s\n%s", mainPath, buf.Bytes())
 	err = os.WriteFile(mainPath, buf.Bytes(), 0o644)
 	if err != nil {
 		return nil, err
@@ -96,7 +99,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 
 	if len(b.EmbedDirs) > 0 {
 		for _, d := range b.EmbedDirs {
-			err = copy(d.Dir, filepath.Join(tempFolder, "files", d.Name))
+			err = copyDir(logger, d.Dir, filepath.Join(tempFolder, "files", d.Name))
 			if err != nil {
 				return nil, err
 			}
@@ -104,7 +107,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 			if err != nil {
 				return nil, fmt.Errorf("embed directory does not exist: %s", d.Dir)
 			}
-			log.Printf("[INFO] Embedding directory: %s", d.Dir)
+			logger.Printf("[INFO] Embedding directory: %s", d.Dir)
 			buf.Reset()
 			tpl, err = template.New("embed").Parse(embeddedModuleTemplate)
 			if err != nil {
@@ -114,7 +117,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 			if err != nil {
 				return nil, err
 			}
-			log.Printf("[INFO] Writing 'embedded' module: %s\n%s", mainPath, buf.Bytes())
+			logger.Printf("[INFO] Writing 'embedded' module: %s\n%s", mainPath, buf.Bytes())
 			emedPath := filepath.Join(tempFolder, "embed.go")
 			err = os.WriteFile(emedPath, buf.Bytes(), 0o644)
 			if err != nil {
@@ -132,10 +135,16 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 		skipCleanup:     b.SkipCleanup,
 		buildFlags:      b.BuildFlags,
 		modFlags:        b.ModFlags,
+		out:             out,
+		logger:          logger,
 	}
 
 	// initialize the go module
-	log.Println("[INFO] Initializing Go module")
+	err = out.beginStep(StepInitializeModule)
+	if err != nil {
+		return nil, err
+	}
+	logger.Println("[INFO] Initializing Go module")
 	cmd := env.newGoModCommand(ctx, "init")
 	cmd.Args = append(cmd.Args, "caddy")
 	err = env.runCommand(ctx, cmd)
@@ -146,7 +155,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 	// specify module replacements before pinning versions
 	replaced := make(map[string]string)
 	for _, r := range b.Replacements {
-		log.Printf("[INFO] Replace %s => %s", r.Old.String(), r.New.String())
+		logger.Printf("[INFO] Replace %s => %s", r.Old.String(), r.New.String())
 		replaced[r.Old.String()] = r.New.String()
 	}
 	if len(replaced) > 0 {
@@ -176,7 +185,11 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 	}
 
 	// pin versions by populating go.mod, first for Caddy itself and then plugins
-	log.Println("[INFO] Pinning versions")
+	err = out.beginStep(StepPinVersions)
+	if err != nil {
+		return nil, err
+	}
+	logger.Println("[INFO] Pinning versions")
 	err = env.execGoGet(ctx, caddyModulePath, env.caddyVersion, "", "")
 	if err != nil {
 		return nil, err
@@ -235,7 +248,7 @@ nextPlugin:
 		return nil, err
 	}
 
-	log.Println("[INFO] Build environment ready")
+	logger.Println("[INFO] Build environment ready")
 	return env, nil
 }
 
@@ -248,24 +261,29 @@ type environment struct {
 	skipCleanup     bool
 	buildFlags      string
 	modFlags        string
+	out             *buildOutput
+	logger          *log.Logger
 }
 
 // Close cleans up the build environment, including deleting
 // the temporary folder from the disk.
 func (env environment) Close() error {
 	if env.skipCleanup {
-		log.Printf("[INFO] Skipping cleanup as requested; leaving folder intact: %s", env.tempFolder)
+		env.logger.Printf("[INFO] Skipping cleanup as requested; leaving folder intact: %s", env.tempFolder)
 		return nil
 	}
-	log.Printf("[INFO] Cleaning up temporary folder: %s", env.tempFolder)
-	return os.RemoveAll(env.tempFolder)
+	// even if the OnStep callback errors, the temporary folder
+	// must still be removed, so that aborting can never leak it
+	stepErr := env.out.beginStep(StepCleanup)
+	env.logger.Printf("[INFO] Cleaning up temporary folder: %s", env.tempFolder)
+	return errors.Join(stepErr, os.RemoveAll(env.tempFolder))
 }
 
 func (env environment) newCommand(ctx context.Context, command string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Dir = env.tempFolder
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = env.out.stdout()
+	cmd.Stderr = env.out.stderr()
 	return cmd
 }
 
@@ -278,7 +296,7 @@ func (env environment) newGoBuildCommand(ctx context.Context, goCommand string, 
 		return nil, fmt.Errorf("unsupported command of 'go': %s", goCommand)
 	}
 	cmd := env.newCommand(ctx, utils.GetGo(), goCommand)
-	cmd = parseAndAppendFlags(cmd, env.buildFlags)
+	cmd = env.parseAndAppendFlags(cmd, env.buildFlags)
 	cmd.Args = append(cmd.Args, args...)
 	return cmd, nil
 }
@@ -288,17 +306,17 @@ func (env environment) newGoBuildCommand(ctx context.Context, goCommand string, 
 func (env environment) newGoModCommand(ctx context.Context, args ...string) *exec.Cmd {
 	args = append([]string{"mod"}, args...)
 	cmd := env.newCommand(ctx, utils.GetGo(), args...)
-	return parseAndAppendFlags(cmd, env.modFlags)
+	return env.parseAndAppendFlags(cmd, env.modFlags)
 }
 
-func parseAndAppendFlags(cmd *exec.Cmd, flags string) *exec.Cmd {
+func (env environment) parseAndAppendFlags(cmd *exec.Cmd, flags string) *exec.Cmd {
 	if strings.TrimSpace(flags) == "" {
 		return cmd
 	}
 
 	fs, err := shlex.Split(flags)
 	if err != nil {
-		log.Printf("[ERROR] Splitting arguments failed: %s", flags)
+		env.logger.Printf("[ERROR] Splitting arguments failed: %s", flags)
 		return cmd
 	}
 	cmd.Args = append(cmd.Args, fs...)
@@ -313,7 +331,7 @@ func (env environment) runCommand(ctx context.Context, cmd *exec.Cmd) error {
 	if ok {
 		timeout = time.Until(deadline)
 	}
-	log.Printf("[INFO] exec (timeout=%s): %+v ", timeout, cmd)
+	env.logger.Printf("[INFO] exec (timeout=%s): %+v ", timeout, cmd)
 
 	// start the command; if it fails to start, report error immediately
 	err := cmd.Start()

--- a/environment.go
+++ b/environment.go
@@ -135,6 +135,7 @@ func (b Builder) newEnvironment(ctx context.Context, out *buildOutput) (*environ
 		skipCleanup:     b.SkipCleanup,
 		buildFlags:      b.BuildFlags,
 		modFlags:        b.ModFlags,
+		env:             b.Env,
 		out:             out,
 		logger:          logger,
 	}
@@ -261,6 +262,7 @@ type environment struct {
 	skipCleanup     bool
 	buildFlags      string
 	modFlags        string
+	env             []string // nil = inherit the process environment
 	out             *buildOutput
 	logger          *log.Logger
 }
@@ -282,6 +284,9 @@ func (env environment) Close() error {
 func (env environment) newCommand(ctx context.Context, command string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Dir = env.tempFolder
+	if env.env != nil {
+		cmd.Env = env.env
+	}
 	cmd.Stdout = env.out.stdout()
 	cmd.Stderr = env.out.stderr()
 	return cmd

--- a/io.go
+++ b/io.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 )
 
-// copy recursively copies src into dst with src's file modes.
-func copy(src, dst string) error {
+// copyDir recursively copies src into dst with src's file modes.
+func copyDir(logger *log.Logger, src, dst string) error {
 	src, _ = filepath.Abs(src)
 	src = filepath.ToSlash(src)
 	dst = filepath.ToSlash(dst)
-	log.Printf("[INFO] copying files: src=%s dest=%s", src, dst)
+	logger.Printf("[INFO] copying files: src=%s dest=%s", src, dst)
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)

--- a/redact.go
+++ b/redact.go
@@ -1,0 +1,136 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xcaddy
+
+import (
+	"bytes"
+	"regexp"
+	"sync"
+)
+
+// redactedPlaceholder replaces sensitive values in step output.
+const redactedPlaceholder = "[REDACTED]"
+
+// maxRedactBuffer caps how much of an unterminated line the
+// redactor will hold before force-flushing it (masked) anyway.
+const maxRedactBuffer = 1 << 20
+
+// redactRule masks either an exact literal value or a pattern.
+type redactRule struct {
+	literal []byte         // if non-nil, exact-match redaction
+	re      *regexp.Regexp // otherwise, pattern redaction
+	repl    []byte         // replacement for pattern matches
+}
+
+func (r redactRule) apply(line []byte) []byte {
+	if r.literal != nil {
+		return bytes.ReplaceAll(line, r.literal, []byte(redactedPlaceholder))
+	}
+	return r.re.ReplaceAll(line, r.repl)
+}
+
+// builtinCredentialRules mask common credential shapes. They are a
+// best-effort backstop for publishable logs, not a guarantee.
+var builtinCredentialRules = []redactRule{
+	// userinfo in URLs: scheme://user:password@host
+	{re: regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)[^/\s@]+@`), repl: []byte("${1}" + redactedPlaceholder + "@")},
+	// GitHub tokens (classic and fine-grained)
+	{re: regexp.MustCompile(`\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}`), repl: []byte(redactedPlaceholder)},
+	{re: regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{20,}`), repl: []byte(redactedPlaceholder)},
+	// GitLab personal access tokens
+	{re: regexp.MustCompile(`\bglpat-[A-Za-z0-9_\-]{16,}`), repl: []byte(redactedPlaceholder)},
+	// Slack tokens
+	{re: regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9\-]{10,}`), repl: []byte(redactedPlaceholder)},
+	// AWS access key IDs
+	{re: regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`), repl: []byte(redactedPlaceholder)},
+}
+
+// key block delimiters for PEM-encoded private key material
+var (
+	keyBlockBegin = regexp.MustCompile(`-----BEGIN [A-Z0-9 ]*PRIVATE KEY( BLOCK)?-----`)
+	keyBlockEnd   = regexp.MustCompile(`-----END [A-Z0-9 ]*PRIVATE KEY( BLOCK)?-----`)
+)
+
+// redactor rewrites sensitive values out of a byte stream before it
+// reaches a step's buffered pipe. It is line-buffered: bytes are
+// held until a newline arrives and each complete line is masked as
+// a unit, so a secret can never slip through by straddling a write
+// boundary. Closing the redactor flushes any unterminated final
+// line (masked) and closes the underlying pipe.
+type redactor struct {
+	dst           *bufferedPipe
+	rules         []redactRule
+	maskKeyBlocks bool
+
+	mu         sync.Mutex
+	buf        []byte
+	inKeyBlock bool
+}
+
+func (r *redactor) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.buf = append(r.buf, p...)
+	for {
+		i := bytes.IndexByte(r.buf, '\n')
+		if i < 0 {
+			break
+		}
+		if _, err := r.dst.Write(r.mask(r.buf[:i+1])); err != nil {
+			return len(p), err
+		}
+		r.buf = r.buf[i+1:]
+	}
+	// don't hold a pathological unterminated line forever
+	if len(r.buf) > maxRedactBuffer {
+		if _, err := r.dst.Write(r.mask(r.buf)); err != nil {
+			return len(p), err
+		}
+		r.buf = nil
+	}
+	return len(p), nil
+}
+
+// Close flushes any buffered partial line (masked) and closes the
+// underlying pipe, delivering EOF to the step's reader.
+func (r *redactor) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.buf) > 0 {
+		_, _ = r.dst.Write(r.mask(r.buf))
+		r.buf = nil
+	}
+	return r.dst.Close()
+}
+
+func (r *redactor) mask(line []byte) []byte {
+	if r.maskKeyBlocks {
+		// mask entire private key blocks, line by line
+		if r.inKeyBlock {
+			if keyBlockEnd.Match(line) {
+				r.inKeyBlock = false
+			}
+			return []byte(redactedPlaceholder + "\n")
+		}
+		if keyBlockBegin.Match(line) {
+			r.inKeyBlock = true
+			return []byte(redactedPlaceholder + "\n")
+		}
+	}
+	for _, rule := range r.rules {
+		line = rule.apply(line)
+	}
+	return line
+}


### PR DESCRIPTION
## Motivation

Programs that embed xcaddy as a library currently have no way to observe a build: all progress goes to the global `log` package and `os.Stdout`/`os.Stderr`, hardwired in `environment.newCommand`. This PR makes builds observable and controllable — e.g. to show live, per-stage progress in a UI — **without changing any existing behavior**: everything is additive, the zero value of `Builder` behaves exactly as before, and the CLI is untouched.

## API

One new callback on `Builder`, plus a step vocabulary:

```go
b := xcaddy.Builder{
    // ...
    OnStep: func(e *xcaddy.StepEvent) error {
        scanner := bufio.NewScanner(e.Output)
        for scanner.Scan() {
            showProgress(e.Step, scanner.Text()) // live, while the step runs
        }
        return scanner.Err() // returns naturally at EOF = step end
    },
}
```

- The build is modeled as named steps: `create_environment` → `initialize_module` → `pin_versions` → (`windows_resources`) → `tidy_module` → `compile` → `cleanup`.
- `StepEvent.Output` is an `io.Reader` over **everything** the step produces: xcaddy's own log lines and the stdout/stderr of the underlying `go` commands. It's backed by a builder-owned buffered pipe whose write side never blocks, so a slow or absent consumer can never stall or deadlock the build. The builder closes the write side at the step boundary, so reading until EOF is the only lifecycle a consumer needs.
- The callback runs in its own goroutine, concurrently with its step; callbacks never overlap (each is joined before the next step begins, and `Build` joins the last one before returning), so consumers need no goroutines, locks, or `WaitGroup`s of their own.
- Returning an error aborts the build at the end of the step, wrapped with the step name (matchable with `errors.Is`/`errors.As`); aborting never leaks the temp folder. As a related fix, errors from the deferred `environment.Close` are now joined into `Build`'s returned error instead of being discarded.

## Safe-to-publish logs (second commit)

For consumers that publish build logs (live progress pages, CI services, multi-tenant builders):

- **`Builder.Env []string`** — hermetic builds: when non-nil, the `go` commands receive exactly this environment instead of inheriting the process's. If the build never had access to a credential (GOPROXY userinfo, git config, `.netrc`, cloud keys), no error message can leak one.
- **`Builder.Secrets []string`** — exact-value redaction: occurrences are replaced with `[REDACTED]` before reaching `StepEvent.Output`. The redactor is line-buffered, so a secret can't slip through by straddling a write boundary.
- **`Builder.RedactCredentials bool`** — best-effort masking of common credential shapes: userinfo in URLs, GitHub/GitLab/Slack token formats, AWS access key IDs, and PEM private key blocks (whole block, stateful across lines).

## Testing

New tests cover: per-step output containment, live line-scanning against a real build, abort semantics with custom errors, callback sequencing guarantees (no overlap, joins at boundaries), unread-output discard, exec's concurrent stdout/stderr drains under `-race`, hermetic-env builds, and redaction (including boundary-straddling secrets, end to end). Network-dependent tests are skipped under `-short` (how CI runs); several integration tests run real partial builds that abort before `pin_versions`, so they exercise `Build` end to end with only local `go` commands.

`go vet`, `gofmt`, and `go test -short -race ./...` are clean; the full networked suite passes as well.