### PR TITLE
docs: show -- when passing Caddy flags through xcaddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,16 +190,17 @@ The current working directory must be inside an initialized Go module.
 Syntax:
 
 ```
-$ xcaddy <args...>
+$ xcaddy [--] <args...>
 ```
 - `<args...>` are passed through to the `caddy` command.
+- Use `--` before Caddy flags (such as `--config`) so that `xcaddy` does not try to parse them as its own flags. Without the separator, commands like `xcaddy run --config caddy.json` fail with `unknown flag: --config`.
 
 For example:
 
 ```bash
 $ xcaddy list-modules
 $ xcaddy run
-$ xcaddy run --config caddy.json
+$ xcaddy -- run --config caddy.json
 ```
 
 The race detector can be enabled by setting `XCADDY_RACE_DETECTOR=1`. The DWARF debug info can be enabled by setting `XCADDY_DEBUG=1`.

--- a/cmd/cobra.go
+++ b/cmd/cobra.go
@@ -18,6 +18,8 @@ var rootCmd = &cobra.Command{
 		"- Compile custom caddy binaries\n" +
 		"- A replacement for `go run` while developing Caddy plugins\n" +
 		"xcaddy accepts any Caddy command (except help and version) to pass through to the custom-built Caddy, notably `run` and `list-modules`.  The command pass-through allows for iterative development process.\n\n" +
+		"When passing flags through to Caddy (for example `--config`), put them after `--` so xcaddy does not parse them:\n" +
+		"  xcaddy -- run --config caddy.json\n\n" +
 		"Report bugs on https://github.com/caddyserver/xcaddy\n",
 	Short:        "Caddy module development helper",
 	SilenceUsage: true,


### PR DESCRIPTION
## Summary

`xcaddy run --config caddy.json` fails with `unknown flag: --config` because cobra parses flags before pass-through. The working form is `xcaddy -- run --config caddy.json`.

This updates the plugin-development examples in the README and mentions the same in the root command long help so the documented usage matches what cobra actually accepts.

Docs-only (plus a one-line help-text note). No CLI behavior change.

## Test plan

- [x] Checked that README examples use `xcaddy -- run --config caddy.json`
- [x] Confirmed root command help text documents the `--` separator
- [ ] Manual: from a module that imports a Caddy plugin, `xcaddy -- run --config caddy.json` runs; bare `xcaddy run --config caddy.json` still errors as before

Fixes #231