### PR TITLE
docs: explain building a plugin together with others

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Syntax:
 ```
 $ xcaddy <args...>
 ```
-- `<args...>` are passed through to the `caddy` command.
+- `<args...>` are passed through to the `caddy` command. This is **not** the place for xcaddy build flags such as `--with`.
 
 For example:
 
@@ -201,6 +201,23 @@ $ xcaddy list-modules
 $ xcaddy run
 $ xcaddy run --config caddy.json
 ```
+
+#### Building with your plugin plus other plugins
+
+The development shortcut above only includes the module in the current directory. Flags like `--with` belong to `xcaddy build`. If you put them on a bare `xcaddy` / `xcaddy run` invocation, they are passed through to Caddy and fail with `unknown flag: --with`.
+
+To produce a binary that includes your local plugin **and** one or more other plugins, use `xcaddy build` with multiple `--with` flags. Point your own module at the current directory with `=.`:
+
+```bash
+# from inside your plugin's module directory
+$ xcaddy build \
+    --with github.com/me/my-plugin=. \
+    --with github.com/mholt/caddy-events-exec
+
+$ ./caddy run
+```
+
+You can add as many `--with` plugins as you need. After the build finishes, run the resulting binary (default `./caddy`) yourself — same as any other custom build.
 
 The race detector can be enabled by setting `XCADDY_RACE_DETECTOR=1`. The DWARF debug info can be enabled by setting `XCADDY_DEBUG=1`.
 


### PR DESCRIPTION
## Summary

When you're in a plugin directory and want Caddy with your plugin *and* other plugins, `xcaddy --with other/plugin run` fails with `unknown flag: --with`.

That's expected: without the `build` subcommand, args are passed through to Caddy. `--with` is a `xcaddy build` flag.

This documents the working pattern:

```bash
xcaddy build \
  --with github.com/me/my-plugin=. \
  --with github.com/mholt/caddy-events-exec
./caddy run
```

Docs only — same approach maintainers already described in #227.

## Test plan

- [x] README spells out that `--with` is for `xcaddy build`, not `xcaddy run`
- [x] Example uses `=.` for the local plugin plus a second `--with`
- [ ] Skim the new subsection under "For plugin development"

Fixes #227