### PR TITLE
fix: Built binaries do not contain tzdata

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -415,6 +415,8 @@ type goModTemplateContext struct {
 const mainModuleTemplate = `package main
 
 import (
+	_ "time/tzdata"
+
 	caddycmd "{{.CaddyModule}}/cmd"
 
 	// plug in Caddy modules here

--- a/environment.go
+++ b/environment.go
@@ -438,6 +438,7 @@ import (
 	"embed"
 	"io/fs"
 	"strings"
+	_ "time/tzdata"
 
 	"{{.CaddyModule}}"
 	"{{.CaddyModule}}/caddyconfig/caddyfile"


### PR DESCRIPTION
Fixes #286.

## Summary

Built binaries do not contain tzdata

## Validation

- Mechanical gate: +2/-0, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->